### PR TITLE
Handle remote file imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -2127,8 +2127,10 @@ async def create_file(
             for file in file_data:
                 if file.filename:  # Ensure that there is a valid filename
                     try:
+                        local_meta = dict(file_metadata)
+                        local_meta["import_or_remote"] = "Import"
                         new_file = bfi.create_file(
-                            file_metadata=file_metadata,
+                            file_metadata=local_meta,
                             file_data=file.file,
                             file_name=file.filename,
                             addl_tags=addl_tags,
@@ -2169,8 +2171,10 @@ async def create_file(
                     and len(file.filename.lstrip(".").lstrip("/").split("/")) < 3
                 ):
                     try:
+                        local_meta = dict(file_metadata)
+                        local_meta["import_or_remote"] = "Import"
                         new_file = bfi.create_file(
-                            file_metadata=file_metadata,
+                            file_metadata=local_meta,
                             file_data=file.file,
                             file_name=file.filename,
                             addl_tags=addl_tags,

--- a/templates/register_file.html
+++ b/templates/register_file.html
@@ -43,10 +43,21 @@
                             <ul>
 
                             {% for field in ui_fields %}
+                                {% if field.name == 'import_or_remote' %}
+                                <div id="import_or_remote_container" style="display:none;">
+                                    <label for="{{ field.name }}">{{ field.label }}</label>
+                                    <select name="{{ field.name }}" id="{{ field.name }}" class="select-filter">
+                                        <option value="" selected></option>
+                                        {% for option in field.options %}
+                                            <option value="{{ option }}">{{ option }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                                {% else %}
                                 <div>
                                     {% if field.type == "select" %}
                                         {% if field.name == "creating_user" %}
-                                          
+
                                         {% else %}
                                         <label for="{{ field.name }}">{{ field.label }}</label>
 
@@ -92,7 +103,8 @@
                                         {% endif %}
                                     {% endif %}
                                 </div>
-                            {% endfor %} 
+                                {% endif %}
+                            {% endfor %}
                         </ul>
                     </ul>
                     </td>
@@ -115,6 +127,11 @@
         const dateInput = document.getElementById('custom-date-start');
         const timeInput = document.getElementById('custom-time-start');
         const mergedField = document.getElementById('record_datetime');
+
+        const importContainer = document.getElementById('import_or_remote_container');
+        const importSelect = document.getElementById('import_or_remote');
+        const urlsField = document.getElementById('urls');
+        const s3Field = document.getElementById('s3_uris');
     
         const dateInpute = document.getElementById('custom-date-end');
         const timeInpute = document.getElementById('custom-time-end');
@@ -139,6 +156,19 @@
         const toggleTimeInputEnd = () => {
             timeInpute.disabled = !dateInpute.value;
         };
+
+        const toggleImportOrRemote = () => {
+            const hasRemote = urlsField.value.trim() !== '' || s3Field.value.trim() !== '';
+            if (hasRemote) {
+                if (importContainer.style.display === 'none') {
+                    importSelect.value = 'Remote';
+                }
+                importContainer.style.display = 'block';
+            } else {
+                importContainer.style.display = 'none';
+                importSelect.value = '';
+            }
+        };
     
         // Attach event listeners
         dateInput.addEventListener('change', () => {
@@ -154,12 +184,16 @@
         });
     
         timeInpute.addEventListener('change', updateMergedFielde);
+
+        urlsField.addEventListener('input', toggleImportOrRemote);
+        s3Field.addEventListener('input', toggleImportOrRemote);
     
         // Initialize the state on page load
         toggleTimeInput();
         toggleTimeInputEnd();
         updateMergedField();
         updateMergedFielde();
+        toggleImportOrRemote();
     });
     
 </script>    


### PR DESCRIPTION
## Summary
- update `register_file` form so the import-or-remote selector appears only when S3 URIs or URLs are supplied
- set uploaded files to always import
- allow importing remote URLs or S3 objects
- keep remote references if import-or-remote is `Remote`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'zebra_day')*

------
https://chatgpt.com/codex/tasks/task_e_6865b99ebd448331be55b52cdb511d83