### PR TITLE
Add option to set starting file index

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,11 @@ git clone git@github.com:Daylily-Informatics/bloom_lims.git
 cd bloom_lims
 
 # This will attempt to build the conda env, install postgres, the database, build the schema and start postgres
-source bloom_lims/env/install_postgres.sh 
+source bloom_lims/env/install_postgres.sh
+
+# To start file identifiers at a custom index, set `FILE_INDEX_START`
+# before sourcing the script:
+# FILE_INDEX_START=5000 source bloom_lims/env/install_postgres.sh
  
 # conda activate BLOOM if is has not happened already.
 
@@ -281,7 +285,7 @@ source clear_and_rebuild_postgres.sh
 - `rm -rf bloom_lims/database/*`
 
 ### Rebuild the schema
--  `source bloom_lims/env/install_postgres.sh skip` the skip will skip building the conda env. This will start pgsql in the env, and build the schema.
+-  `source bloom_lims/env/install_postgres.sh skip` the skip will skip building the conda env. This will start pgsql in the env, and build the schema. Use `FILE_INDEX_START=<num>` before the command to set the starting file index.
 
 ### Build LIMS Workflows With Autogen Objects
 Similar to `pytest`, but more extensive. Largely useful in development work.  The following will auto-gen 'n=2' passes of the lims schema

--- a/bloom_lims/env/install_postgres.sh
+++ b/bloom_lims/env/install_postgres.sh
@@ -2,10 +2,12 @@
 
 # Conda install steps credit: https://gist.github.com/gwangjinkim/f13bf596fefa7db7d31c22efd1627c7a
 
-PGDATA=${PGDATA:-bloom_lims/database/bloom_lims} 
+PGDATA=${PGDATA:-bloom_lims/database/bloom_lims}
 PGUSER=${PGUSER:-$USER}
 PGPASSWORD=${PGPASSWORD:-passw0rd}
 export PGDBNAME=${PGDBNAME:-bloom_lims}
+# Optional starting value for the file index sequence (FI euid prefix)
+FILE_INDEX_START=${FILE_INDEX_START:-$2}
 
 
 source bloom_lims/bin/install_miniconda
@@ -71,6 +73,13 @@ if [[ $? -ne 0 ]]; then
 else
     echo "Database schema and tables created successfully."
     echo "You may use the pgsql datastore $PGDATA to connect to the '$PGDBNAME' databse using $PGUSER and pw: $PGPASSWORD and connect to database: $PGDBNAME ."
+fi
+
+if [[ -n "$FILE_INDEX_START" ]]; then
+    echo "Setting starting file index to $FILE_INDEX_START"
+    PGPORT=5445 psql -U "$PGUSER" -d "$PGDBNAME" -c "ALTER SEQUENCE fi_instance_seq RESTART WITH $FILE_INDEX_START;" || {
+        echo "Failed to set file index start" && return 1
+    }
 fi
 
 echo "\n\n\nSeeding the database templates now...\n\n\n"


### PR DESCRIPTION
## Summary
- allow supplying FILE_INDEX_START to install_postgres.sh
- document new FILE_INDEX_START environment variable in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68661d6525448331b85efc56bac4ffb8