### PR TITLE
Allow duplicate S3 URI records

### DIFF
--- a/bloom_lims/bobjs.py
+++ b/bloom_lims/bobjs.py
@@ -3194,8 +3194,8 @@ class BloomFile(BloomObj):
                     b_sub_type="generic",
                 )
                 if len(existing_euids) > 0:
-                    raise Exception(
-                        f"Remote file with URI {s3_uri} already exists in the database as {existing_euids}."
+                    self.logger.warning(
+                        f"Remote file with URI {s3_uri} already exists in the database as {existing_euids}. Creating a new record anyway."
                     )
 
                 file_properties = {


### PR DESCRIPTION
## Summary
- allow duplicate S3 URI uploads by logging a warning instead of raising an error

## Testing
- `pytest -q` *(fails: OperationalError connecting to database)*

------
https://chatgpt.com/codex/tasks/task_e_686628c586508331bec0b9ecf969f04a