### PR TITLE
Default fileset names use datestamp

### DIFF
--- a/main.py
+++ b/main.py
@@ -1940,10 +1940,12 @@ async def delete_edge(request: Request, _auth=Depends(require_auth)):
 
 
 def generate_unique_upload_key():
-    color = random.choice(BVARS.pantone_colors)
-    invertebrate = random.choice(BVARS.marine_invertebrates)
-    number = random.randint(0, 1000000)
-    return f"{color.replace(' ','_')}_{invertebrate.replace(' ','_')}_{number}"
+    """Return a datestamp for default file set names.
+
+    The datestamp format follows ``YYYYMMDDTHHMMSS`` as required when a
+    file set name isn't explicitly provided.
+    """
+    return datetime.utcnow().strftime("%Y%m%dT%H%M%S")
 
 
 
@@ -2276,7 +2278,12 @@ async def create_file(
         user_data = request.session.get("user_data", {})
         style = {"skin_css": user_data.get("style_css", "static/skins/bloom.css")}
         content = templates.get_template("create_file_report.html").render(
-            request=request, results=results, style=style, udat=user_data
+            request=request,
+            results=results,
+            style=style,
+            udat=user_data,
+            file_set_euid=new_file_set.euid,
+            file_set_name=file_set_name,
         )
 
         return HTMLResponse(content=content)

--- a/templates/create_file_report.html
+++ b/templates/create_file_report.html
@@ -73,6 +73,13 @@
     {% include 'bloom_header.html' %}
 
     <h1>Create File Report</h1>
+    {% if file_set_euid %}
+    <p>File Set:
+        <a target="_blank" href="euid_details?euid={{ file_set_euid }}">
+            {{ file_set_name }}
+        </a>
+    </p>
+    {% endif %}
     <hr>
     <table>
         <thead>


### PR DESCRIPTION
## Summary
- generate a datestamp for default file set names
- show link to created file set in the create-file report

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_6866276fccb483318477aa95daeef434