### PR TITLE
Add DB backup and restore controls

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import subprocess
 from typing import List
 from pathlib import Path
 import random
+import asyncio
 
 import csv
 import os
@@ -120,6 +121,10 @@ BVARS = BloomVars()
 BASE_DIR = Path("./served_data").resolve()  # Base directory for serving files
 
 from auth.supabase.connection import create_supabase_client
+
+
+# Lock to serialize backup and restore operations
+db_lock = asyncio.Lock()
 
 
 # local udata prefernces
@@ -309,6 +314,34 @@ async def get_relationship_data(obj):
                 )
             ]
     return relationship_data
+
+
+def _pg_env():
+    env = os.environ.copy()
+    env.setdefault("PGHOST", "localhost")
+    env.setdefault("PGPORT", "5445")
+    env.setdefault("PGUSER", env.get("USER", "bloom"))
+    env.setdefault("PGPASSWORD", env.get("PGPASSWORD", "passw0rd"))
+    env.setdefault("PGDBNAME", env.get("PGDBNAME", "bloom"))
+    return env
+
+
+def pg_dump_file(out_path: Path):
+    env = _pg_env()
+    cmd = ["pg_dump", "-Fp", env["PGDBNAME"]]
+    with open(out_path, "w") as fh:
+        subprocess.run(cmd, stdout=fh, check=True, env=env)
+
+
+def pg_restore_file(sql_path: Path):
+    env = _pg_env()
+    # Drop existing objects to ensure the restore can proceed
+    drop_cmd = ["psql", env["PGDBNAME"], "-c", "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;"]
+    subprocess.run(drop_cmd, check=True, env=env)
+
+    cmd = ["psql", env["PGDBNAME"], "-v", "ON_ERROR_STOP=1"]
+    with open(sql_path, "r") as fh:
+        subprocess.run(cmd, stdin=fh, check=True, env=env)
 
 
 class RequireAuthException(HTTPException):
@@ -804,6 +837,13 @@ async def admin(request: Request, _auth=Depends(require_auth), dest="na"):
     ]  # Get just the file names
 
     printer_info["style_css"] = csss
+
+    backup_path = user_data.get("db_backup_path", "./db_backups")
+    if os.path.isdir(backup_path):
+        backup_files = sorted([p.name for p in Path(backup_path).glob("*.sql")], reverse=True)
+    else:
+        backup_files = []
+
     style = {"skin_css": user_data.get("style_css", "static/skins/bloom.css")}
 
     # Rendering the template with the dynamic content
@@ -813,6 +853,8 @@ async def admin(request: Request, _auth=Depends(require_auth), dest="na"):
         user_data=user_data,
         printer_info=printer_info,
         dest_section=dest_section,
+        backup_path=backup_path,
+        backups=backup_files,
         udat=request.session["user_data"],
     )
 
@@ -849,6 +891,30 @@ async def update_preference(request: Request, auth: dict = Depends(require_auth)
         return {"status": "success", "message": "User preference updated"}
     else:
         return {"status": "error", "message": "User not found in user data"}
+
+
+@app.post("/db_backup")
+async def db_backup(request: Request, _auth=Depends(require_auth)):
+    backup_path = request.session["user_data"].get("db_backup_path", "./db_backups")
+    os.makedirs(backup_path, exist_ok=True)
+    outfile = Path(backup_path) / f"backup_{get_clean_timestamp()}.sql"
+    async with db_lock:
+        await asyncio.to_thread(pg_dump_file, outfile)
+    return RedirectResponse(url="/admin?dest=backup", status_code=303)
+
+
+@app.post("/db_restore")
+async def db_restore(request: Request, filename: str = Form(...), _auth=Depends(require_auth)):
+    backup_path = request.session["user_data"].get("db_backup_path", "./db_backups")
+    target = Path(backup_path) / filename
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="Backup not found")
+    os.makedirs(backup_path, exist_ok=True)
+    new_backup = Path(backup_path) / f"pre_restore_{get_clean_timestamp()}.sql"
+    async with db_lock:
+        await asyncio.to_thread(pg_dump_file, new_backup)
+        await asyncio.to_thread(pg_restore_file, target)
+    return RedirectResponse(url="/admin?dest=backup", status_code=303)
 
 
 @app.get("/queue_details", response_class=HTMLResponse)
@@ -3115,11 +3181,11 @@ def directory_listing(directory: Path, file_path: str) -> HTMLResponse:
     for item in items:
         if item.is_dir():
             files.append(
-                f'<li><a href="/serve_endpoint/{file_path.lstrip('/')}/{item.name}/">{item.name}/</a></li>'
+                f"<li><a href='/serve_endpoint/{file_path.lstrip('/')}/{item.name}/'>{item.name}/</a></li>"
             )
         else:
             files.append(
-                f'<li><a href="/serve_endpoint/{file_path.lstrip('/')}/{item.name}">{item.name}</a></li>'
+                f"<li><a href='/serve_endpoint/{file_path.lstrip('/')}/{item.name}'>{item.name}</a></li>"
             )
     print('PPPPPP', str(parent_path))
     html_content = f"""

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -49,6 +49,40 @@
         <a style="display: none;" href="/workflow_summary">Original Raw Workflow View (not intended for operational use)</a>
     </h2>
 
+    <div id="backup-section">
+        <h3>Database Backups</h3>
+        <table>
+            <tr>
+                <td>Backup Directory:</td>
+                <td>
+                    <input type="text" value="{{ user_data.get('db_backup_path', './db_backups') }}" onchange="updatePreferenceAndReload('db_backup_path', this.value)">
+                    <form method="post" action="/db_backup" style="display:inline;">
+                        <button type="submit">Dump Backup</button>
+                    </form>
+                </td>
+            </tr>
+        </table>
+
+        {% if backups %}
+        <table border="1">
+            <tr><th>Backup File</th><th>Action</th></tr>
+            {% for b in backups %}
+            <tr>
+                <td>{{ b }}</td>
+                <td>
+                    <form method="post" action="/db_restore" onsubmit="return confirm('Restore from {{ b }}? This will overwrite the current database.');">
+                        <input type="hidden" name="filename" value="{{ b }}">
+                        <button type="submit">Restore</button>
+                    </form>
+                </td>
+            </tr>
+            {% endfor %}
+        </table>
+        {% else %}
+        <p>No backups found in {{ backup_path }}</p>
+        {% endif %}
+    </div>
+
 
      <script>    
     function updatePreferenceAndReload(key, value) {


### PR DESCRIPTION
## Summary
- add async locking for DB maintenance
- implement helper functions to dump and restore Postgres DB
- expose `/db_backup` and `/db_restore` endpoints
- show available backups in admin page
- allow backup path preference with UI controls
- drop existing schema before restoring and prompt user to confirm restore

## Testing
- `python -m py_compile main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686628438518833197689d8c4ec4ece3