### PR TITLE
Fix detach issue when importing file data

### DIFF
--- a/bloom_lims/bobjs.py
+++ b/bloom_lims/bobjs.py
@@ -3421,9 +3421,10 @@ class BloomFile(BloomObj):
             file_instance.json_addl["properties"]["comments"] = (
                 str(e) + f" FILENAM == {file_name}"
             )
+            # Reattach the object in case the session was rolled back
+            file_instance = self.session.merge(file_instance)
             flag_modified(file_instance, "json_addl")
             flag_modified(file_instance, "bstatus")
-            self.session.flush()
             self.session.commit()
             raise (e)
 


### PR DESCRIPTION
## Summary
- handle potential session rollback in `add_file_data`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68662e9596f48331b68364578e2a56fc