### PR TITLE
Fix schema restore conflict

### DIFF
--- a/main.py
+++ b/main.py
@@ -342,7 +342,7 @@ def pg_restore_file(sql_path: Path):
         "psql",
         env["PGDBNAME"],
         "-c",
-        f"DROP SCHEMA IF EXISTS {schema} CASCADE; CREATE SCHEMA {schema};",
+        f"DROP SCHEMA IF EXISTS {schema} CASCADE;",
     ]
     subprocess.run(drop_cmd, check=True, env=env)
 


### PR DESCRIPTION
## Summary
- fix DB schema restoration step so it doesn't recreate the schema before loading the backup

## Testing
- `python -m pytest -q` *(fails: OperationalError connecting to database)*

------
https://chatgpt.com/codex/tasks/task_e_68663c1b88a883318a9361e3b30e0311