### PR TITLE
Fix S3 URI import path

### DIFF
--- a/bloom_lims/bobjs.py
+++ b/bloom_lims/bobjs.py
@@ -3301,6 +3301,13 @@ class BloomFile(BloomObj):
                     "import_or_remote": import_or_remote,
                 }
 
+                _update_recursive(
+                    file_instance.json_addl["properties"], file_properties
+                )
+                flag_modified(file_instance, "json_addl")
+                self.session.commit()
+                return file_instance
+
         try:
             if file_data:
                 file_data.seek(0)  # Ensure the file pointer is at the beginning


### PR DESCRIPTION
## Summary
- handle S3 imports separately in `add_file_data`

## Testing
- `pytest tests/test_file_creations.py::test_create_file_no_data -q` *(fails: OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_6866348ec2c48331bc93f88b9d00fad6