### PR TITLE
Enable customizable column order for search results

### DIFF
--- a/main.py
+++ b/main.py
@@ -260,6 +260,14 @@ def highlight_json_changes(old_json_str, new_json_str):
     return '\n'.join(old_json_highlighted), '\n'.join(new_json_highlighted)
 
 
+def apply_column_order(columns, order_pref):
+    """Reorder columns based on user preference."""
+    if isinstance(order_pref, list):
+        ordered = [c for c in order_pref if c in columns]
+        remaining = [c for c in columns if c not in ordered]
+        return ordered + remaining
+    return columns
+
 async def get_relationship_data(obj):
     relationship_data = {}
     for relationship in obj.__mapper__.relationships:
@@ -775,6 +783,8 @@ async def query_by_euids(request: Request, file_euids: str = Form(...)):
             table_data.append(row)
 
         user_data = request.session.get("user_data", {})
+        order_pref = user_data.get("search_columns_order")
+        columns = apply_column_order(columns, order_pref)
         style = {"skin_css": user_data.get("style_css", "static/skins/bloom.css")}
 
         content = templates.get_template("search_results.html").render(
@@ -2594,6 +2604,8 @@ async def search_files(
             table_data.append(row)
 
         user_data = request.session.get("user_data", {})
+        order_pref = user_data.get("search_columns_order")
+        columns = apply_column_order(columns, order_pref)
         style = {"skin_css": user_data.get("style_css", "static/skins/bloom.css")}
         fset_templates = bobdb.query_template_by_component_v2("file","file_set","generic","1.0")
   
@@ -2803,6 +2815,8 @@ async def search_file_sets(
             table_data.append(row)
 
         user_data = request.session.get("user_data", {})
+        order_pref = user_data.get("file_set_search_columns_order")
+        columns = apply_column_order(columns, order_pref)
         style = {"skin_css": user_data.get("style_css", "static/skins/bloom.css")}
 
         num_results = len(table_data)

--- a/templates/file_set_search_results.html
+++ b/templates/file_set_search_results.html
@@ -5,6 +5,9 @@
     {% set page_title = 'File Search Results' %}
     <title>{{ page_title }}</title>
     {% set bloom_mod = 'dewey' %}
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
 
     <link rel="stylesheet" type="text/css" href="{{ style.skin_css }}">
     <link rel="stylesheet" type="text/css" href="static/style.css">
@@ -13,6 +16,11 @@
     {% include 'bloom_header.html' %}
 
     <h1>{{ num_results }} Results</h1>
+    <button onclick="openColumnModal()" type="button">Edit Column Order</button>
+    <div id="column-modal" title="Column Order" style="display:none;">
+        <ul id="column-list">{% for col in columns %}<li class="ui-state-default" data-col="{{ col }}">{{ col }}</li>{% endfor %}</ul>
+        <button onclick="saveColumnOrder()" type="button">Save</button>
+    </div>
 
     <table id="results-table" border="1">
         <thead>
@@ -91,6 +99,19 @@
             document.body.removeChild(downloadLink);
         }
     </script>
+<script>
+    $(function(){
+        $("#column-list").sortable();
+        $("#column-modal").dialog({ autoOpen: false, modal: true });
+    });
+    function openColumnModal(){
+        $("#column-modal").dialog("open");
+    }
+    function saveColumnOrder(){
+        const order = $("#column-list").sortable("toArray", { attribute: "data-col" });
+        $.ajax({url: "/update_preference", type: "POST", contentType: "application/json", data: JSON.stringify({key: "file_set_search_columns_order", value: order}), success: function(){ location.reload(); }});
+    }
+</script>
 
     <style>
         .floating-button {

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -13,6 +13,8 @@
     <script src="static/action_buttons.js"></script>
 
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/css/selectize.css" />
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/js/standalone/selectize.min.js"></script>
     <script>
@@ -251,6 +253,11 @@
     {% include 'bloom_header.html' %}
 
     <b>{{ n_results }} File Search Results</b>
+    <button onclick="openColumnModal()" type="button">Edit Column Order</button>
+    <div id="column-modal" title="Column Order" style="display:none;">
+        <ul id="column-list">{% for col in columns %}<li class="ui-state-default" data-col="{{ col }}">{{ col }}</li>{% endfor %}</ul>
+        <button onclick="saveColumnOrder()" type="button">Save</button>
+    </div>
     <form id="fileSetForm" action="/create_file_set" method="post"  >
         <div style="display: flex; flex:none;">
             <div class="form-section" style="background-color: rgba(204, 255, 204, 0.1); flex:none;">
@@ -502,6 +509,19 @@
     });
 </script>
 
+<script>
+    $(function(){
+        $("#column-list").sortable();
+        $("#column-modal").dialog({ autoOpen: false, modal: true });
+    });
+    function openColumnModal(){
+        $("#column-modal").dialog("open");
+    }
+    function saveColumnOrder(){
+        const order = $("#column-list").sortable("toArray", { attribute: "data-col" });
+        $.ajax({url: "/update_preference", type: "POST", contentType: "application/json", data: JSON.stringify({key: "search_columns_order", value: order}), success: function(){ location.reload(); }});
+    }
+</script>
     {% include 'pre_body_close.html' %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow users to persist preferred column order via `apply_column_order`
- support configurable order in file search and file set search results
- add UI elements and jQuery UI sortable controls to reorder columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686635cce528833199ed6c0f4bb24a08