### PR TITLE
Enable customizable column order for search results

### DIFF
--- a/main.py
+++ b/main.py
@@ -260,6 +260,14 @@ def highlight_json_changes(old_json_str, new_json_str):
     return '\n'.join(old_json_highlighted), '\n'.join(new_json_highlighted)
 
 
+def apply_column_order(columns, order_pref):
+    """Reorder columns based on user preference."""
+    if isinstance(order_pref, list):
+        ordered = [c for c in order_pref if c in columns]
+        remaining = [c for c in columns if c not in ordered]
+        return ordered + remaining
+    return columns
+
 async def get_relationship_data(obj):
     relationship_data = {}
     for relationship in obj.__mapper__.relationships:
@@ -775,6 +783,8 @@ async def query_by_euids(request: Request, file_euids: str = Form(...)):
             table_data.append(row)
 
         user_data = request.session.get("user_data", {})
+        order_pref = user_data.get("search_columns_order")
+        columns = apply_column_order(columns, order_pref)
         style = {"skin_css": user_data.get("style_css", "static/skins/bloom.css")}
 
         content = templates.get_template("search_results.html").render(
@@ -2594,6 +2604,8 @@ async def search_files(
             table_data.append(row)
 
         user_data = request.session.get("user_data", {})
+        order_pref = user_data.get("search_columns_order")
+        columns = apply_column_order(columns, order_pref)
         style = {"skin_css": user_data.get("style_css", "static/skins/bloom.css")}
         fset_templates = bobdb.query_template_by_component_v2("file","file_set","generic","1.0")
   
@@ -2803,6 +2815,8 @@ async def search_file_sets(
             table_data.append(row)
 
         user_data = request.session.get("user_data", {})
+        order_pref = user_data.get("file_set_search_columns_order")
+        columns = apply_column_order(columns, order_pref)
         style = {"skin_css": user_data.get("style_css", "static/skins/bloom.css")}
 
         num_results = len(table_data)

--- a/templates/file_set_search_results.html
+++ b/templates/file_set_search_results.html
@@ -5,6 +5,9 @@
     {% set page_title = 'File Search Results' %}
     <title>{{ page_title }}</title>
     {% set bloom_mod = 'dewey' %}
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
 
     <link rel="stylesheet" type="text/css" href="{{ style.skin_css }}">
     <link rel="stylesheet" type="text/css" href="static/style.css">
@@ -12,14 +15,24 @@
 <body>
     {% include 'bloom_header.html' %}
 
-    <h1>{{ num_results }} Results</h1>
+    <div style="display:flex; justify-content:space-between; align-items:center;">
+        <h1 style="margin:0;">{{ num_results }} Results</h1>
+        <div>
+            <button onclick="openColumnModal()" type="button">Edit Column Order</button>
+            <button onclick="downloadTableAsTSV()" type="button">⬇️</button>
+        </div>
+    </div>
+    <div id="column-modal" title="Column Order" style="display:none;">
+        <ul id="column-list">{% for col in columns %}<li class="ui-state-default" data-col="{{ col }}">{{ col }}</li>{% endfor %}</ul>
+        <button onclick="saveColumnOrder()" type="button">Save</button>
+    </div>
 
     <table id="results-table" border="1">
         <thead>
             <tr>
                 <th>Link</th> <!-- New column header for the link -->
                 {% for column in columns %}
-                <th onclick="sortTable({{ loop.index0 }})">{{ column }}</th>
+                <th onclick="sortTableByHeader(this)">{{ column }}</th>
                 {% endfor %}
             </tr>
         </thead>
@@ -47,20 +60,20 @@
 
     <a href="/dewey">Go Back</a>
 
-    <button class="floating-button" onclick="downloadTableAsTSV()">⬇️ Download TSV</button>
-
     <script>
         let sortDirections = Array({{ columns | length }}).fill(true); // Track sort direction for each column
 
-        function sortTable(columnIndex) {
+        function sortTableByHeader(header) {
             const table = document.getElementById('results-table');
+            const columnIndex = Array.from(header.parentNode.children).indexOf(header) - 1; // subtract 1 for the link column
+            if (columnIndex < 0) return;
             const tbody = table.tBodies[0];
             const rows = Array.from(tbody.rows);
 
             const direction = sortDirections[columnIndex] ? 1 : -1;
 
             const sortedRows = rows.sort((a, b) => {
-                const cellA = a.cells[columnIndex + 1].innerText.toLowerCase(); // +1 because of new first column
+                const cellA = a.cells[columnIndex + 1].innerText.toLowerCase();
                 const cellB = b.cells[columnIndex + 1].innerText.toLowerCase();
 
                 if (cellA < cellB) return -1 * direction;
@@ -69,7 +82,7 @@
             });
 
             tbody.append(...sortedRows);
-            sortDirections[columnIndex] = !sortDirections[columnIndex]; // Toggle sort direction
+            sortDirections[columnIndex] = !sortDirections[columnIndex];
         }
 
         function downloadTableAsTSV() {
@@ -91,24 +104,21 @@
             document.body.removeChild(downloadLink);
         }
     </script>
+<script>
+    $(function(){
+        $("#column-list").sortable();
+        $("#column-modal").dialog({ autoOpen: false, modal: true });
+    });
+    function openColumnModal(){
+        $("#column-modal").dialog("open");
+    }
+    function saveColumnOrder(){
+        const order = $("#column-list").sortable("toArray", { attribute: "data-col" });
+        $.ajax({url: "/update_preference", type: "POST", contentType: "application/json", data: JSON.stringify({key: "file_set_search_columns_order", value: order}), success: function(){ location.reload(); }});
+    }
+</script>
 
     <style>
-        .floating-button {
-            position: fixed;
-            bottom: 10px;
-            right: 10px;
-            padding: 10px;
-            background-color: #008CBA; /* Blue background */
-            color: white; /* White text */
-            border: none;
-            text-align: center;
-            text-decoration: none;
-            display: inline-block;
-            font-size: 16px;
-            cursor: pointer;
-            border-radius: 50%;
-        }
-
         th {
             cursor: pointer;
         }

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -13,6 +13,8 @@
     <script src="static/action_buttons.js"></script>
 
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
+    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/css/selectize.css" />
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/js/standalone/selectize.min.js"></script>
     <script>
@@ -108,29 +110,6 @@
             document.body.removeChild(downloadLink);
         }
 
-        function sortTable(columnIndex) {
-            const table = document.querySelector('table');
-            const rows = Array.from(table.querySelectorAll('tbody > tr'));
-            const header = table.querySelector(`thead > tr > th:nth-child(${columnIndex + 1})`);
-            const isAscending = header.classList.contains('ascending');
-
-            rows.sort((a, b) => {
-                const aText = a.children[columnIndex].innerText.trim();
-                const bText = b.children[columnIndex].innerText.trim();
-
-                if (!isNaN(aText) && !isNaN(bText)) {
-                    return isAscending ? aText - bText : bText - aText;
-                } else {
-                    return isAscending ? aText.localeCompare(bText) : bText.localeCompare(aText);
-                }
-            });
-
-            rows.forEach(row => table.querySelector('tbody').appendChild(row));
-            table.querySelectorAll('thead > tr > th').forEach(th => th.classList.remove('ascending', 'descending'));
-
-            header.classList.toggle('ascending', !isAscending);
-            header.classList.toggle('descending', isAscending);
-        }
     </script>
 
 
@@ -251,6 +230,11 @@
     {% include 'bloom_header.html' %}
 
     <b>{{ n_results }} File Search Results</b>
+    <button onclick="openColumnModal()" type="button">Edit Column Order</button>
+    <div id="column-modal" title="Column Order" style="display:none;">
+        <ul id="column-list">{% for col in columns %}<li class="ui-state-default" data-col="{{ col }}">{{ col }}</li>{% endfor %}</ul>
+        <button onclick="saveColumnOrder()" type="button">Save</button>
+    </div>
     <form id="fileSetForm" action="/create_file_set" method="post"  >
         <div style="display: flex; flex:none;">
             <div class="form-section" style="background-color: rgba(204, 255, 204, 0.1); flex:none;">
@@ -353,18 +337,18 @@
     <table border="1">
         <thead>
             <tr>
-                <th onclick="sortTable(0)" class="download-column">
+                <th onclick="sortTableByHeader(this)" class="download-column">
                     <input type="checkbox" id="select-all-download" onclick="toggleSelectAll('.file-checkbox', 'select-all-download')">
                     Flag to download
                 </th>
-                <th onclick="sortTable(1)" class="file-set-column">
+                <th onclick="sortTableByHeader(this)" class="file-set-column">
                     <input type="checkbox" id="select-all-file-set" onclick="toggleSelectAll('.file-set-checkbox', 'select-all-file-set')">
                     Create File Set
                 </th>
                 {% for column in columns %}
-                <th onclick="sortTable({{ loop.index + 1 }})">{{ column }}</th>
+                <th onclick="sortTableByHeader(this)">{{ column }}</th>
                 {% endfor %}
-                <th onclick="sortTable({{ columns|length + 2 }})">S3 URI</th>
+                <th onclick="sortTableByHeader(this)">S3 URI</th>
             </tr>
         </thead>
         <tbody>
@@ -458,10 +442,10 @@
             }
         } 
 
-        function sortTable(columnIndex) {
-            const table = document.querySelector('table');
+        function sortTableByHeader(header) {
+            const table = header.closest('table');
+            const columnIndex = Array.from(header.parentNode.children).indexOf(header);
             const rows = Array.from(table.querySelectorAll('tbody > tr'));
-            const header = table.querySelector(`thead > tr > th:nth-child(${columnIndex + 1})`);
             const isAscending = header.classList.contains('ascending');
 
             rows.sort((a, b) => {
@@ -502,6 +486,19 @@
     });
 </script>
 
+<script>
+    $(function(){
+        $("#column-list").sortable();
+        $("#column-modal").dialog({ autoOpen: false, modal: true });
+    });
+    function openColumnModal(){
+        $("#column-modal").dialog("open");
+    }
+    function saveColumnOrder(){
+        const order = $("#column-list").sortable("toArray", { attribute: "data-col" });
+        $.ajax({url: "/update_preference", type: "POST", contentType: "application/json", data: JSON.stringify({key: "search_columns_order", value: order}), success: function(){ location.reload(); }});
+    }
+</script>
     {% include 'pre_body_close.html' %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow users to persist preferred column order via `apply_column_order`
- support configurable order in file search and file set search results
- add UI elements and jQuery UI sortable controls to reorder columns
- fix column reordering with dynamic sort indices
- place file set TSV download button beside the heading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686635cce528833199ed6c0f4bb24a08