### PR TITLE
Fix TSV download button

### DIFF
--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -345,7 +345,7 @@
                 <small>
                 d/l<br>table<br>as<br>TSV<br>
                 </small>
-                <button type="submit" class="download-tsv" onclick="downloadTableAsTSV()">⬇️</button>
+                <button type="button" class="download-tsv" onclick="downloadTableAsTSV()">⬇️</button>
             </div>
 
         </div>


### PR DESCRIPTION
## Summary
- ensure the "download table as TSV" button does not submit the create file set form

## Testing
- `pytest -q` *(fails: No module named 'yaml')*
- `pip install -r requirements.txt` *(fails: Getting requirements to build wheel did not run successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6866761f492c8331a91276f6d201f3cf