### PR TITLE
Update bulk create file return naming

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -3507,4 +3507,8 @@ async def bulk_create_files_from_tsv(request: Request, file: UploadFile = File(.
         for row, result in zip(rows, results):
             writer.writerow({**row, **result, "FileSet": bulk_file_set.euid})
 
-    return FileResponse(fin_tsv_path, media_type="text/tab-separated-values")
+    return FileResponse(
+        fin_tsv_path,
+        media_type="text/tab-separated-values",
+        filename=fin_tsv_path.name,
+    )


### PR DESCRIPTION
## Summary
- ensure returned TSV uses FileSet UID prefix by supplying filename param

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686677cf2e6c83318a87868aa69b5a0f