### PR TITLE
Fix DAG display by persisting session data

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1876,7 +1876,11 @@ def generate_dag_json_from_all_objects_v2(
         return
 
     request.session["schema_mod_dt"] = last_schema_edit_dt.changed_at.isoformat()
-    request.session["user_data"]["dag_fnv2"] = output_file
+
+    # Update nested session data safely
+    user_data = request.session.get("user_data", {})
+    user_data["dag_fnv2"] = output_file
+    request.session["user_data"] = user_data
 
     colors = {
         "container": "#8B00FF",  # Electric Purple


### PR DESCRIPTION
## Summary
- update session handling so `dag_fnv2` persists between requests

## Testing
- `pytest -q` *(fails: OperationalError psycopg2 connection to remote host)*

------
https://chatgpt.com/codex/tasks/task_e_686676c1c720833199b54bd0e3898bfd