### PR TITLE
Improve bulk file creation results view

### DIFF
--- a/templates/create_file_report.html
+++ b/templates/create_file_report.html
@@ -101,6 +101,9 @@
             {% endfor %}
         </tbody>
     </table>
+    {% if results_tsv %}
+    <p><a href="{{ results_tsv }}" download>Download results TSV</a></p>
+    {% endif %}
     <hr>
     <a href="/dewey">Back to Create File Form</a>
 


### PR DESCRIPTION
## Summary
- after bulk file create show the regular confirmation table
- make results TSV available via link on the page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68667ea86dd083319c0db08b16e611cf