### PR TITLE
Remove floating download button from file set search results

### DIFF
--- a/templates/file_set_search_results.html
+++ b/templates/file_set_search_results.html
@@ -44,7 +44,6 @@
 
         </div>
     </form>
-    <button type="button" class="floating-button download-tsv" onclick="downloadTableAsTSV()">⬇️</button>
 
     <table id="results-table" border="1">
         <thead>
@@ -152,10 +151,6 @@
     <style>
         th {
             cursor: pointer;
-        }
-        .floating-button.download-tsv {
-            top: 20px;
-            bottom: auto;
         }
     </style>
 </body>


### PR DESCRIPTION
## Summary
- remove extra floating download button
- clean up unused styling for the removed button

## Testing
- `pytest -q` *(fails: connection to remote DB unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68667fd5763c8331b0c8a9ccea76eaa4