### PR TITLE
Refactor index2 Dewey section

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1348,6 +1348,23 @@ async def database_statistics(request: Request, _auth=Depends(require_auth)):
     )
     return HTMLResponse(content=content)
 
+
+@app.get("/dewey_counts", response_class=JSONResponse)
+async def dewey_counts(request: Request, _auth=Depends(require_auth)):
+    bobdb = BloomObj(BLOOMdb3(app_username=request.session["user_data"]["email"]))
+    GI = bobdb.Base.classes.generic_instance
+    file_count = (
+        bobdb.session.query(GI)
+        .filter(GI.btype == "file", GI.is_deleted == False)
+        .count()
+    )
+    file_set_count = (
+        bobdb.session.query(GI)
+        .filter(GI.btype == "file_set", GI.is_deleted == False)
+        .count()
+    )
+    return {"files": file_count, "file_sets": file_set_count}
+
 @app.post("/save_json_addl_key")
 async def save_json_addl_key(request: Request):
     try:

--- a/templates/dewey.html
+++ b/templates/dewey.html
@@ -166,7 +166,7 @@
     <h1>File Tools</h1>
     <hr>
     
-    <button class="accordion" style="width: -webkit-fill-available;">Register File(s)</button>
+    <button id="register-files" class="accordion" style="width: -webkit-fill-available;">Register File(s)</button>
     <div class="accordion-content" data-form="register">
         {% include 'register_file.html' %}
     </div>
@@ -178,7 +178,7 @@
     </div>
     <hr><hr>
     
-    <button class="accordion" style="width: -webkit-fill-available;">File Search (bulk d/l | create file sets | create presigned s3 URLS | share via HTTP/SFTP/webDAV/...)</button>
+    <button id="query-files" class="accordion" style="width: -webkit-fill-available;">File Search (bulk d/l | create file sets | create presigned s3 URLS | share via HTTP/SFTP/webDAV/...)</button>
     <div class="accordion-content" data-form="search">
         {% include 'file_search.html' %}
     </div>
@@ -190,7 +190,7 @@
     </div>
     <hr><hr>
 
-    <button class="accordion" style="width: -webkit-fill-available;">Search File Sets</button>
+    <button id="query-file-sets" class="accordion" style="width: -webkit-fill-available;">Search File Sets</button>
     <div class="accordion-content">
         {% include 'search_file_sets.html' %}
     </div>
@@ -276,6 +276,18 @@
         window.addEventListener('pageshow', function(event) {
             if (event.persisted || (window.performance && window.performance.navigation.type === 2)) {
                 resetForms();
+            }
+        });
+
+        document.addEventListener('DOMContentLoaded', function() {
+            if (window.location.hash) {
+                var target = document.querySelector(window.location.hash);
+                if (target && target.classList.contains('accordion')) {
+                    target.classList.add('active');
+                    var panel = target.nextElementSibling;
+                    if (panel) { panel.style.display = 'block'; }
+                    target.scrollIntoView();
+                }
             }
         });
     </script>

--- a/templates/index2.html
+++ b/templates/index2.html
@@ -85,15 +85,41 @@
     <body>
         {% include 'bloom_header.html' %}
 
-        <ul style="padding: 0;"><div class="button-container" style="margin-top: 20px; text-align: center;padding: 0;">
-            <a href="/serve_endpoint" style="display: inline-block; margin: 20px; padding: 20px 40px; background-color: #28a745; color: white; text-decoration: none; font-size: 24px; border-radius: 8px;">Navigate Data Directories</a>
-            <a href="/dewey" style="display: inline-block; margin: 20px; padding: 20px 40px; background-color: #17a2b8; color: white; text-decoration: none; font-size: 24px; border-radius: 8px;">DEWEY</a>
+        <div class="button-container" style="margin-top:20px; text-align:center;">
+            <h2>DEWEY</h2>
+            <a href="/dewey" class="idx_button" style="padding:20px 40px; font-size:24px; background-color:#17a2b8; color:white;">DEWEY</a>
+            <div style="margin-top:10px;">
+                <a href="/dewey#register-files" class="idx_button">Register Files</a>
+                <a href="/dewey#query-files" class="idx_button">Query Files</a>
+                <a href="/dewey#queryAll" class="idx_button">All Files</a>
+                <a href="/dewey#query-file-sets" class="idx_button">Query File Sets</a>
+                <a href="/dewey#searchFileSetFormALL" class="idx_button">All File Sets</a>
+            </div>
+            <div id="dewey-stats" style="margin-top:10px;"></div>
         </div>
-        <br><br><br><hr><hr><br>
-        <div>
-            <a href="/admin" style="display: inline-block; margin: 20px; padding: 20px 40px; background-color: rgb(10,44,77); color: gray; text-decoration: none; font-size: 24px; border-radius: 8px;">ADMIN</a>
 
-            <a href="/lims" style="display: none; margin: 20px; padding: 20px 40px; background-color: rgb(77,44,10); color: gray; text-decoration: none; font-size: 24px; border-radius: 8px;">LIMS</a>
+        <hr>
+
+        <div class="button-container" style="text-align:center;">
+            <h2>Navigate Data Directories</h2>
+            <a href="/serve_endpoint" class="idx_button" style="padding:20px 40px; font-size:24px; background-color:#28a745; color:white;">Navigate Data Directories</a>
         </div>
+
+        <hr>
+
+        <div class="button-container" style="text-align:center;">
+            <h2>Admin</h2>
+            <a href="/admin" class="idx_button" style="padding:20px 40px; font-size:24px; background-color:rgb(10,44,77); color:gray;">ADMIN</a>
+        </div>
+
+        <script>
+            fetch('/dewey_counts')
+                .then(r => r.json())
+                .then(d => {
+                    document.getElementById('dewey-stats').innerText =
+                        `Files: ${d.files} | File Sets: ${d.file_sets}`;
+                })
+                .catch(e => console.error('Failed to load stats', e));
+        </script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- add quick navigation links and stats to index2
- add IDs to Dewey accordions and open via location hash
- provide simple API for Dewey counts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68668389d078833195a27b83c47e1005