### PR TITLE
Refactor templates to share snippets

### DIFF
--- a/templates/assay.html
+++ b/templates/assay.html
@@ -12,30 +12,7 @@
     <script src="/static/action_buttons.js"></script>
 
 
-    <style>
-        .accordion {
-            cursor: pointer;
-            padding: 18px;
-            width: 100%;
-            border: none;
-            text-align: left;
-            outline: none;
-            font-size: 15px;
-            transition: 0.4s;
-        }
-     
-        .panel {
-            padding: 0 18px;
-            display: none;
-            overflow: hidden;
-        }
-        b {
-            color: gold;        
-        }
-        button .accordion {  
-            background-color: var(--secondary-color);
-        }
-    </style>
+    {% include "includes/accordion_styles.html" %}
 </head>
 <body>
     {% include 'bloom_header.html' %}

--- a/templates/includes/accordion_styles.html
+++ b/templates/includes/accordion_styles.html
@@ -1,0 +1,34 @@
+<style>
+    .accordion {
+        cursor: pointer;
+        padding: 18px;
+        width: 100%;
+        border: none;
+        text-align: left;
+        outline: none;
+        font-size: 15px;
+        transition: 0.4s;
+    }
+
+    .panel {
+        padding: 0 18px;
+        display: none;
+        overflow: hidden;
+    }
+    b {
+        color: gold;
+    }
+    button .accordion {
+        background-color: var(--secondary-color);
+    }
+    .blink {
+        animation: blinker 1s linear infinite;
+        color: red;
+        font-weight: bold;
+    }
+    @keyframes blinker {
+        50% {
+            opacity: 0;
+        }
+    }
+</style>

--- a/templates/includes/base.html
+++ b/templates/includes/base.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>{{ page_title }}</title>
+        <link rel="stylesheet" type="text/css" href="{{ style.skin_css }}">
+        <link rel="stylesheet" type="text/css" href="static/style.css">
+        <script src="static/action_buttons.js"></script>
+        {% block extra_head %}{% endblock %}
+    </head>
+    <body>
+        {% include 'bloom_header.html' %}
+        {% block content %}{% endblock %}
+    </body>
+</html>

--- a/templates/includes/oauth_script.html
+++ b/templates/includes/oauth_script.html
@@ -1,0 +1,35 @@
+<script>
+    function checkForOauthCode() {
+        const urlFragment = new URLSearchParams(window.location.hash.substring(1));
+        const accessToken = urlFragment.get('access_token');
+        console.log("Access token:", accessToken);
+
+        if (accessToken) {
+            fetch('/oauth_callback', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ accessToken: accessToken }),
+            })
+            .then(response => response.text())
+            .then(data => {
+                console.log("Response from server:", data);
+                if (!sessionStorage.getItem('pageReloaded')) {
+                    sessionStorage.setItem('pageReloaded', 'true');
+                    window.location.reload();
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert("Failed to process GitHub authentication.");
+            });
+        } else {
+            console.log("No GitHub code found on home page.");
+        }
+    }
+
+    window.onload = function() {
+        checkForOauthCode();
+    };
+</script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,97 +1,15 @@
-<!DOCTYPE html>
-<html>
-    <head>
-        {% set page_title = 'Bloom' %}
-        <title>{{ page_title }}</title>
+{% extends 'includes/base.html' %}
+{% set page_title = 'Bloom' %}
+{% set bloom_mod = 'index' %}
 
-        {% set bloom_mod = 'index' %}
+{% block extra_head %}
+    {% include 'includes/oauth_script.html' %}
+    {% include 'includes/accordion_styles.html' %}
+{% endblock %}
 
-        <link rel="stylesheet" type="text/css" href="{{ style.skin_css }}">
-        <link rel="stylesheet" type="text/css" href="static/style.css">
-        <script src="static/action_buttons.js"></script>
-
-        <script>
-            function checkForOauthCode() {
-                const urlFragment = new URLSearchParams(window.location.hash.substring(1)); // Remove the # and parse
-                const accessToken = urlFragment.get('access_token');
-                console.log("Access token:", accessToken);
-            
-                if (accessToken) {
-                    // Send the code to the backend
-                    fetch('/oauth_callback', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({ accessToken: accessToken }),
-                    })
-                    .then(response => response.text())
-                    .then(data => {
-                        console.log("Response from server:", data);
-                        if (!sessionStorage.getItem('pageReloaded')) {
-                            sessionStorage.setItem('pageReloaded', 'true');
-                            window.location.reload(); // Force page reload
-                        }
-                    })
-                    .catch(error => {
-                        console.error('Error:', error);
-                        alert("Failed to process GitHub authentication.");
-                    });
-                } else {
-                    console.log("No GitHub code found on home page.");
-                }
-            }
-
-            window.onload = function() {
-                checkForOauthCode();
-            };
-
-
-        </script>
-
-        <style>
-            .accordion {
-                cursor: pointer;
-                padding: 18px;
-                width: 100%;
-                border: none;
-                text-align: left;
-                outline: none;
-                font-size: 15px;
-                transition: 0.4s;
-            }
-         
-            .panel {
-                padding: 0 18px;
-                display: none;
-                overflow: hidden;
-            }
-            b {
-                color: gold;        
-            }
-            button .accordion {  
-                background-color: var(--secondary-color);
-            }
-            .blink {
-                animation: blinker 1s linear infinite;
-                color: red;
-                font-weight: bold;
-            }
-            @keyframes blinker {
-                50% {
-                    opacity: 0;
-                }
-            }
-        </style>
-    </head>
-    <body>
-        {% include 'bloom_header.html' %}
-
-        <ul style="padding: 0;"><div class="button-container" style="margin-top: 20px; text-align: center;padding: 0;">
-
-            <a href="/index2" style="display: inline-block; margin: 20px; padding: 20px 40px; background-color: #28a745; color: magenta; text-decoration: none; font-size: 24px; border-radius: 8px;">... Please Authenticate To Proceed ...</a>
-
-        </div>
-
-    </body>
-</html>
+{% block content %}
+<ul style="padding: 0;">
+    <div class="button-container" style="margin-top: 20px; text-align: center;padding: 0;">
+        <a href="/index2" style="display: inline-block; margin: 20px; padding: 20px 40px; background-color: #28a745; color: magenta; text-decoration: none; font-size: 24px; border-radius: 8px;">... Please Authenticate To Proceed ...</a>
+    </div>
+{% endblock %}

--- a/templates/index2.html
+++ b/templates/index2.html
@@ -1,99 +1,21 @@
-<!DOCTYPE html>
-<html>
-    <head>
-        {% set page_title = 'rcrf-dewey' %}
-        <title>{{ page_title }}</title>
+{% extends 'includes/base.html' %}
+{% set page_title = 'rcrf-dewey' %}
+{% set bloom_mod = 'index' %}
 
-        {% set bloom_mod = 'index' %}
+{% block extra_head %}
+    {% include 'includes/oauth_script.html' %}
+    {% include 'includes/accordion_styles.html' %}
+{% endblock %}
 
-        <link rel="stylesheet" type="text/css" href="{{ style.skin_css }}">
-        <link rel="stylesheet" type="text/css" href="static/style.css">
-        <script src="static/action_buttons.js"></script>
-
-        <script>
-            function checkForOauthCode() {
-                const urlFragment = new URLSearchParams(window.location.hash.substring(1)); // Remove the # and parse
-                const accessToken = urlFragment.get('access_token');
-                console.log("Access token:", accessToken);
-            
-                if (accessToken) {
-                    // Send the code to the backend
-                    fetch('/oauth_callback', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({ accessToken: accessToken }),
-                    })
-                    .then(response => response.text())
-                    .then(data => {
-                        console.log("Response from server:", data);
-                        if (!sessionStorage.getItem('pageReloaded')) {
-                            sessionStorage.setItem('pageReloaded', 'true');
-                            window.location.reload(); // Force page reload
-                        }
-                    })
-                    .catch(error => {
-                        console.error('Error:', error);
-                        alert("Failed to process GitHub authentication.");
-                    });
-                } else {
-                    console.log("No GitHub code found on home page.");
-                }
-            }
-
-            window.onload = function() {
-                checkForOauthCode();
-            };
-        </script>
-
-        <style>
-            .accordion {
-                cursor: pointer;
-                padding: 18px;
-                width: 100%;
-                border: none;
-                text-align: left;
-                outline: none;
-                font-size: 15px;
-                transition: 0.4s;
-            }
-         
-            .panel {
-                padding: 0 18px;
-                display: none;
-                overflow: hidden;
-            }
-            b {
-                color: gold;        
-            }
-            button .accordion {  
-                background-color: var(--secondary-color);
-            }
-            .blink {
-                animation: blinker 1s linear infinite;
-                color: red;
-                font-weight: bold;
-            }
-            @keyframes blinker {
-                50% {
-                    opacity: 0;
-                }
-            }
-        </style>
-    </head>
-    <body>
-        {% include 'bloom_header.html' %}
-
-        <ul style="padding: 0;"><div class="button-container" style="margin-top: 20px; text-align: center;padding: 0;">
-            <a href="/serve_endpoint" style="display: inline-block; margin: 20px; padding: 20px 40px; background-color: #28a745; color: white; text-decoration: none; font-size: 24px; border-radius: 8px;">Navigate Data Directories</a>
-            <a href="/dewey" style="display: inline-block; margin: 20px; padding: 20px 40px; background-color: #17a2b8; color: white; text-decoration: none; font-size: 24px; border-radius: 8px;">DEWEY</a>
-        </div>
-        <br><br><br><hr><hr><br>
-        <div>
-            <a href="/admin" style="display: inline-block; margin: 20px; padding: 20px 40px; background-color: rgb(10,44,77); color: gray; text-decoration: none; font-size: 24px; border-radius: 8px;">ADMIN</a>
-
-            <a href="/lims" style="display: none; margin: 20px; padding: 20px 40px; background-color: rgb(77,44,10); color: gray; text-decoration: none; font-size: 24px; border-radius: 8px;">LIMS</a>
-        </div>
-    </body>
-</html>
+{% block content %}
+<ul style="padding: 0;">
+    <div class="button-container" style="margin-top: 20px; text-align: center;padding: 0;">
+        <a href="/serve_endpoint" style="display: inline-block; margin: 20px; padding: 20px 40px; background-color: #28a745; color: white; text-decoration: none; font-size: 24px; border-radius: 8px;">Navigate Data Directories</a>
+        <a href="/dewey" style="display: inline-block; margin: 20px; padding: 20px 40px; background-color: #17a2b8; color: white; text-decoration: none; font-size: 24px; border-radius: 8px;">DEWEY</a>
+    </div>
+    <br><br><br><hr><hr><br>
+    <div>
+        <a href="/admin" style="display: inline-block; margin: 20px; padding: 20px 40px; background-color: rgb(10,44,77); color: gray; text-decoration: none; font-size: 24px; border-radius: 8px;">ADMIN</a>
+        <a href="/lims" style="display: none; margin: 20px; padding: 20px 40px; background-color: rgb(77,44,10); color: gray; text-decoration: none; font-size: 24px; border-radius: 8px;">LIMS</a>
+    </div>
+{% endblock %}

--- a/templates/lims_main.html
+++ b/templates/lims_main.html
@@ -10,41 +10,7 @@
         <link rel="stylesheet" type="text/css" href="{{ style.skin_css }}">
         <link rel="stylesheet" type="text/css" href="static/style.css">
         <script src="static/action_buttons.js"></script>
-
-        <style>
-            .accordion {
-                cursor: pointer;
-                padding: 18px;
-                width: 100%;
-                border: none;
-                text-align: left;
-                outline: none;
-                font-size: 15px;
-                transition: 0.4s;
-            }
-         
-            .panel {
-                padding: 0 18px;
-                display: none;
-                overflow: hidden;
-            }
-            b {
-                color: gold;        
-            }
-            button .accordion {  
-                background-color: var(--secondary-color);
-            }
-            .blink {
-                animation: blinker 1s linear infinite;
-                color: red;
-                font-weight: bold;
-            }
-            @keyframes blinker {
-                50% {
-                    opacity: 0;
-                }
-            }
-        </style>
+        {% include 'includes/accordion_styles.html' %}
     </head>
     <body>
 


### PR DESCRIPTION
## Summary
- centralize layout in `templates/includes/base.html`
- extract OAuth JavaScript and accordion styles into reusable includes
- refactor `index.html`, `index2.html`, `assay.html`, and `lims_main.html` to use the new includes

## Testing
- `pytest -q` *(fails: connection to Postgres host blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6866854726388331bd08fb1742b0f742