### PR TITLE
Refactor templates for DRYness

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,36 +1,25 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
+{% extends 'includes/base.html' %}
+{% set page_title = 'Admin' %}
+{% set bloom_mod = 'admin' %}
 
-    {% set page_title = 'Admin' %}
-    <title>{{ page_title }}</title>
-    
-    {% set bloom_mod = 'admin' %}
-
-
-    <link rel="stylesheet" type="text/css" href="{{ style.skin_css }}"  >
-    <link rel="stylesheet" type="text/css" href="static/style.css">
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js" > </script>
-
-    <style> 
+{% block extra_head %}
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <style>
     </style>
     <script>
         $(document).ready(function() {
-            // Assuming 'dest_section.sec' is a variable available in your templating engine
             {% if dest_section.section == 'skin' %}
                 $('#skin-css-section').addClass('flash-effect');
-            {% elif  dest_section.section == 'zebra' %}
+            {% elif dest_section.section == 'zebra' %}
                 $('#zebra-css-section').addClass('flash-effect');
-            {% elif  dest_section.section == 'template' %}
+            {% elif dest_section.section == 'template' %}
                 $('#template-css-section').addClass('flash-effect');
             {% endif %}
         });
     </script>
-</head>
-<body>
+{% endblock %}
 
-    {% include 'bloom_header.html' %}
+{% block content %}
     <br>
 <ul>
     <h2>Dewey Administration</h2>
@@ -83,25 +72,5 @@
         <p>No backups found in {{ backup_path }}</p>
         {% endif %}
     </div>
-
-
-     <script>    
-    function updatePreferenceAndReload(key, value) {
-        console.log('Updating', key, 'to', value);
-        $.ajax({
-            url: '/update_preference',
-            type: 'POST',
-            contentType: 'application/json', // Specify the content type
-            data: JSON.stringify({ key: key, value: value }), // Convert the data to a JSON string
-            success: function(response) {
-                console.log('Update successful:', response);
-                window.location.reload();
-            },
-            error: function(xhr, status, error) {
-                console.error('Update failed:', status, error);
-            }
-        });
-        
-    }
-    </script>
-</body>
+    {% include 'includes/update_preference_script.html' %}
+{% endblock %}

--- a/templates/includes/update_preference_script.html
+++ b/templates/includes/update_preference_script.html
@@ -1,0 +1,18 @@
+<script>
+function updatePreferenceAndReload(key, value) {
+    console.log('Updating', key, 'to', value);
+    $.ajax({
+        url: '/update_preference',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({ key: key, value: value }),
+        success: function(response) {
+            console.log('Update successful:', response);
+            window.location.reload();
+        },
+        error: function(xhr, status, error) {
+            console.error('Update failed:', status, error);
+        }
+    });
+}
+</script>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,14 +1,8 @@
-<!DOCTYPE html>
-<html>
-    <head>
+{% extends 'includes/base.html' %}
+{% set page_title = 'Bloom Login' %}
+{% set bloom_mod = 'admin' %}
 
-        {% set page_title = 'Bloom Login' %}
-        <title>{{ page_title }}</title>
-
-        {% set bloom_mod = 'admin' %}
-
-        <link rel="stylesheet" type="text/css" href="{{ style.skin_css }}"  >
-        <link rel="stylesheet" type="text/css" href="static/style.css">
+{% block extra_head %}
 <script>
     function validateEmail(email) {
         try {
@@ -71,9 +65,9 @@
       }
     }
 </script>
+{% endblock %}
 
-    </head>
-    <body>
+{% block content %}
         {% include 'bloom_header.html' %}
 
         <div id="error-message" style="color: red;"></div> <!-- Error message display -->
@@ -94,5 +88,4 @@
 
 
   
-    </body>
-</html>
+    {% endblock %}

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -1,17 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
+{% extends 'includes/base.html' %}
+{% set page_title = 'File Search Results' %}
+{% set bloom_mod = 'dewey' %}
 
-    {% set page_title = 'File Search Results' %}
-    <title>{{ page_title }}</title>
-
-    {% set bloom_mod = 'dewey' %}
-
-    <link rel="stylesheet" type="text/css" href="{{ style.skin_css }}">
-    <link rel="stylesheet" type="text/css" href="static/style.css">
+{% block extra_head %}
     <script src="static/action_buttons.js"></script>
-
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/css/selectize.css" />
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/js/standalone/selectize.min.js"></script>
@@ -246,8 +238,9 @@
             background-color: var(--form-in-bg-color);
         }
     </style>
-</head>
-<body>
+{% endblock %}
+
+{% block content %}
     {% include 'bloom_header.html' %}
 
     <b>{{ n_results }} File Search Results</b>
@@ -503,5 +496,4 @@
 </script>
 
     {% include 'pre_body_close.html' %}
-</body>
-</html>
+{% endblock %}

--- a/templates/user_home.html
+++ b/templates/user_home.html
@@ -1,15 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
+{% extends 'includes/base.html' %}
+{% set page_title = 'User Home' %}
+{% set bloom_mod = 'user_home' %}
 
-    {% set page_title = 'User Home' %}
-    <title>{{ page_title }}</title>
-    
-    {% set bloom_mod = 'user_home' %}
-
-    <link rel="stylesheet" type="text/css" href="{{ style.skin_css }}">
-    <link rel="stylesheet" type="text/css" href="static/style.css">
+{% block extra_head %}
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 
     <style>
@@ -62,9 +55,9 @@
             {% endif %}
         });
     </script>
-</head>
-<body>
-    
+{% endblock %}
+
+{% block content %}
     {% include 'bloom_header.html' %}
 <ul>
     <h1>Welcome, {{ user_data.email }}</h1>
@@ -220,23 +213,5 @@
     </td></tr></table>
 
 </ul>
-    <script>
-        function updatePreferenceAndReload(key, value) {
-            console.log('Updating', key, 'to', value);
-            $.ajax({
-                url: '/update_preference',
-                type: 'POST',
-                contentType: 'application/json',
-                data: JSON.stringify({ key: key, value: value }),
-                success: function(response) {
-                    console.log('Update successful:', response);
-                    window.location.reload();
-                },
-                error: function(xhr, status, error) {
-                    console.error('Update failed:', status, error);
-                }
-            });
-        }
-    </script>
-</body>
-</html>
+    {% include 'includes/update_preference_script.html' %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- create reusable update_preference_script include
- refactor admin, user_home, login and search_results templates to extend `base.html`
- share update_preference_script where used

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68669064c0548331b9630441208834b6