### PR TITLE
Fix missing bulk results download

### DIFF
--- a/templates/create_file_report.html
+++ b/templates/create_file_report.html
@@ -103,6 +103,17 @@
     </table>
     {% if results_tsv %}
     <p><a href="{{ results_tsv }}" download>Download results TSV</a></p>
+    <script>
+        window.addEventListener('DOMContentLoaded', function() {
+            var link = document.createElement('a');
+            link.href = '{{ results_tsv }}';
+            link.download = '';
+            link.style.display = 'none';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        });
+    </script>
     {% endif %}
     <hr>
     <a href="/dewey">Back to Create File Form</a>


### PR DESCRIPTION
## Summary
- automatically download `filesetUID_dewey_bulk_create_outcomes.tsv` when bulk creation completes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686694264c208331a91fadc5438fe86f