### PR TITLE
Fix search header duplication and restyle index2 buttons

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -90,6 +90,36 @@ button:hover {
     margin: 1px;
     transition: background-color var(--transition-speed);
 }
+.idx_button:visited {
+    color: var(--text-color);
+}
+
+.main-button {
+    padding: 12px 40px;
+    display: inline-block;
+}
+
+.idx_section {
+    text-align: center;
+    padding-bottom: 20px;
+}
+
+.idx_subbuttons {
+    margin-top: 10px;
+    padding-top: 10px;
+}
+
+.dewey-button {
+    background-color: var(--primary-color);
+}
+
+.navigate-button {
+    background-color: var(--secondary-color);
+}
+
+.admin-button {
+    background-color: var(--accent-color);
+}
     
 form {
     padding: 0px;

--- a/templates/index2.html
+++ b/templates/index2.html
@@ -8,24 +8,27 @@
 {% endblock %}
 
 {% block content %}
-<div style="padding:0; margin-top:20px; text-align:center;">
-    <a class="idx_button" href="/dewey" style="font-size:24px; padding:20px 40px;">DEWEY</a>
-    <div style="margin-top:10px;">
+<div class="idx_section dewey-section">
+    <a class="idx_button dewey-button main-button" href="/dewey">DEWEY</a>
+    <div class="idx_subbuttons">
         <a class="idx_button" href="/dewey#register-files">Register Files</a>
         <a class="idx_button" href="/dewey#query-files">Query Files</a>
-        <a class="idx_button" href="/dewey?all_files=1#query-files">All Files</a>
+        <form style="display:inline;" action="/query_by_euids" method="post">
+            <input type="hidden" name="file_euids" value="">
+            <button class="idx_button" type="submit">All Files</button>
+        </form>
         <a class="idx_button" href="/dewey#query-file-sets">Query File Sets</a>
         <a class="idx_button" href="/dewey?all_file_sets=1#query-file-sets">All File Sets</a>
     </div>
-    <div id="dewey-stats" style="margin-top:10px;font-size:14px;color:var(--text-color);"></div>
+    <div id="dewey-stats" class="idx_stats"></div>
 </div>
 <hr>
-<div style="text-align:center; margin-top:20px;">
-    <a class="idx_button" href="/serve_endpoint" style="font-size:24px; padding:20px 40px;">Navigate Data Directories</a>
+<div class="idx_section navigate-section">
+    <a class="idx_button navigate-button main-button" href="/serve_endpoint">Navigate Data Directories</a>
 </div>
 <hr>
-<div style="text-align:center; margin-top:20px;">
-    <a class="idx_button" href="/admin" style="font-size:24px; padding:20px 40px;">ADMIN</a>
+<div class="idx_section admin-section">
+    <a class="idx_button admin-button main-button" href="/admin">ADMIN</a>
     <a href="/lims" style="display:none"></a>
 </div>
 <script>

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -241,7 +241,6 @@
 {% endblock %}
 
 {% block content %}
-    {% include 'bloom_header.html' %}
 
     <b>{{ n_results }} File Search Results</b>
     <form id="fileSetForm" action="/create_file_set" method="post"  >


### PR DESCRIPTION
## Summary
- remove extra header include from search results
- update index page buttons with distinct colors and spacing
- ensure visited index buttons keep text color consistent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: yaml, boto3)*

------
https://chatgpt.com/codex/tasks/task_e_686699fbf6d8833196ab4bd39effcc53