### PR TITLE
Fix duplicate header on user home page

### DIFF
--- a/templates/user_home.html
+++ b/templates/user_home.html
@@ -58,7 +58,6 @@
 {% endblock %}
 
 {% block content %}
-    {% include 'bloom_header.html' %}
 <ul>
     <h1>Welcome, {{ user_data.email }}</h1>
     <ul>


### PR DESCRIPTION
## Summary
- remove second copy of `bloom_header` from `user_home.html`

## Testing
- `pytest -q` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6866a025caf08331bf4839c9449cde17