### PR TITLE
Fix all files search

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -4,7 +4,7 @@ import httpx
 import os
 import json
 import subprocess
-from typing import List
+from typing import List, Optional
 from pathlib import Path
 import random
 import asyncio
@@ -799,10 +799,13 @@ async def Acalculate_cogs_children(euid, request: Request, _auth=Depends(require
         return json.dumps({"success": False, "message": str(e)})
 
 @app.post("/query_by_euids", response_class=HTMLResponse)
-async def query_by_euids(request: Request, file_euids: str = Form(...)):
+async def query_by_euids(request: Request, file_euids: Optional[str] = Form(None)):
     try:
         bfi = BloomFile(BLOOMdb3(app_username=request.session["user_data"]["email"]))
-        euid_list = [euid.strip() for euid in file_euids.split("\n") if euid.strip()]
+        if file_euids:
+            euid_list = [euid.strip() for euid in file_euids.split("\n") if euid.strip()]
+        else:
+            euid_list = bfi.search_objs_by_addl_metadata({}, True, "file", super_type="file")
 
         detailed_results = [bfi.get_by_euid(euid) for euid in euid_list if euid]
 

--- a/templates/file_search.html
+++ b/templates/file_search.html
@@ -2,9 +2,9 @@
     <ul>
         <h3>Search Files</h3>
         <form id="queryAll" action="query_by_euids" method="post" enctype="multipart/form-data">
-            <input type=hidden id="file_euids" name="file_euids" >
-            <button type="submit" id="queryByEuidsButton">return all records</button>
-        </form> ... or SEARCH 
+            <input type="hidden" id="file_euids_all" name="file_euids" >
+            <button type="submit" id="queryAllButton">return all records</button>
+        </form> ... or SEARCH
         <hr>
         <table>
             <tr style="vertical-align: top;">


### PR DESCRIPTION
## Summary
- allow `query_by_euids` to handle empty requests and return all files
- avoid duplicate IDs in file search HTML form

## Testing
- `pytest -q` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6866a1d28470833190f5cd89ce201859