### PR TITLE
Add styling for tagify input

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -15,6 +15,16 @@ input, textarea, select, file {
     /* ... other styles ... */
 }
 
+/* Style Tagify input like standard form fields */
+.tagify{
+    background-color: var(--form-in-bg-color);
+    border-radius: var(--border-radius);
+    color: var(--form-color);
+    border: 3px solid var(--form-border-color);
+    margin: 2px;
+    padding: 0px;
+}
+
 body {
     font-family: var(--font-family);
     background-color: var(--background-color);


### PR DESCRIPTION
## Summary
- style Tagify file tag field like other form inputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6866b39c09d48331b8c3b4511693fa9f