### PR TITLE
Add file set tags

### DIFF
--- a/bloom_lims/bobjs.py
+++ b/bloom_lims/bobjs.py
@@ -3966,6 +3966,20 @@ class BloomFileSet(BloomObj):
         self.session.commit()
         return file_set
 
+    def get_unique_file_set_tags(self):
+        """Return a list of unique tags across all file sets."""
+        q = text(
+            """
+            SELECT DISTINCT jsonb_array_elements_text(json_addl->'properties'->'tags') AS tag
+            FROM generic_instance
+            WHERE super_type = 'file' AND btype = 'file_set' AND is_deleted = :is_deleted
+            AND jsonb_typeof(json_addl->'properties'->'tags') = 'array'
+            """
+        )
+        result = self.session.execute(q, {"is_deleted": self.is_deleted})
+        rows = result.fetchall()
+        return [r[0] for r in rows if r[0]]
+
     def get_file_set_by_euid(self, euid):
         return self.get_by_euid(euid)
 

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -800,6 +800,17 @@ async def file_tag_suggestions(request: Request, q: str = ""):
     return tags
 
 
+@app.get("/file_set_tag_suggestions", response_class=JSONResponse)
+async def file_set_tag_suggestions(request: Request, q: str = ""):
+    """Return a list of existing file set tags starting with q."""
+    bdb = BLOOMdb3(app_username=request.session.get("user_data", {}).get("email", "na"))
+    bfs = BloomFileSet(bdb)
+    tags = bfs.get_unique_file_set_tags()
+    if q:
+        tags = [t for t in tags if t.lower().startswith(q.lower())]
+    return tags
+
+
 @app.get("/calculate_cogs_children")
 async def Acalculate_cogs_children(euid, request: Request, _auth=Depends(require_auth)):
     try:
@@ -2761,6 +2772,7 @@ async def create_file_set(
     name: str = Form(None),
     description: str = Form(None),
     tag: str = Form(None),
+    tags: str = Form(""),
     comments: str = Form(None),
     file_euids: str = Form(None),
     ref_type: str = Form("na"),
@@ -2787,6 +2799,7 @@ async def create_file_set(
             "name": name,
             "description": description,
             "tag": tag,
+            "tags": [t for t in tags.split() if t],
             "comments": comments,
             "ref_type": ref_type,
             "duration": duration,

--- a/templates/create_file_set.html
+++ b/templates/create_file_set.html
@@ -9,8 +9,6 @@
 
                 {% elif field.name == "ref_type" %}
 
-                {% elif field.name == "tags" %}
-
                 {% elif field.type == "select" %}
                     
                       
@@ -86,5 +84,18 @@
     // Call the function on page load to set the correct state
     document.addEventListener("DOMContentLoaded", function() {
         toggleRcloneOptions();
+
+        const tagInput = document.getElementById('tags');
+        if (tagInput) {
+            const tagify = new Tagify(tagInput, {
+                delimiters: ' ',
+                pattern: /[^\s]+/,
+                originalInputValueFormat: values => values.map(v => v.value).join(' ')
+            });
+
+            fetch('/file_set_tag_suggestions')
+                .then(r => r.json())
+                .then(data => { tagify.settings.whitelist = data; });
+        }
     });
 </script>

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -5,6 +5,8 @@
 {% block extra_head %}
     <script src="static/action_buttons.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="static/tagify.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="static/tagify.css">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/css/selectize.css" />
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.3/js/standalone/selectize.min.js"></script>
     <script>
@@ -277,8 +279,6 @@
         
                         {% elif field.name == "ref_type" %}
         
-                        {% elif field.name == "tags" %}
-        
                         {% elif field.type == "select" %}
                             
                               
@@ -491,6 +491,18 @@
     // Call the function on page load to set the correct state
     document.addEventListener("DOMContentLoaded", function() {
         toggleRcloneOptions();
+        const tagInput = document.getElementById('tags');
+        if (tagInput) {
+            const tagify = new Tagify(tagInput, {
+                delimiters: ' ',
+                pattern: /[^\s]+/,
+                originalInputValueFormat: values => values.map(v => v.value).join(' ')
+            });
+
+            fetch('/file_set_tag_suggestions')
+                .then(r => r.json())
+                .then(data => { tagify.settings.whitelist = data; });
+        }
     });
 </script>
 


### PR DESCRIPTION
## Summary
- expose name and tags in file set forms
- support Tagify for file set tags
- backend support for listing file set tags
- collect tags from create_file_set endpoint

## Testing
- `pytest -q` *(fails: psycopg2 OperationalError: connection to server failed)*

------
https://chatgpt.com/codex/tasks/task_e_6866b63944008331b1ff803d9d405626