### PR TITLE
Add preview popups for presigned file links

### DIFF
--- a/static/preview.js
+++ b/static/preview.js
@@ -1,0 +1,46 @@
+document.addEventListener("DOMContentLoaded", function() {
+    const previewBox = document.createElement('div');
+    previewBox.id = 'file-preview-box';
+    previewBox.style.position = 'absolute';
+    previewBox.style.display = 'none';
+    previewBox.style.border = '1px solid #ccc';
+    previewBox.style.background = 'white';
+    previewBox.style.padding = '5px';
+    previewBox.style.zIndex = '1000';
+    document.body.appendChild(previewBox);
+
+    function showPreview(event) {
+        const url = event.currentTarget.href;
+        const ext = url.split('.').pop().toLowerCase().split(/[#?]/)[0];
+        if (["pdf", "png", "jpg", "jpeg", "gif"].includes(ext)) {
+            previewBox.innerHTML = '';
+            if (ext === 'pdf') {
+                previewBox.innerHTML = `<embed src="${url}" type="application/pdf" width="600" height="400">`;
+            } else {
+                previewBox.innerHTML = `<img src="${url}" style="max-width:600px; max-height:400px;">`;
+            }
+            previewBox.style.left = event.pageX + 20 + 'px';
+            previewBox.style.top = event.pageY + 20 + 'px';
+            previewBox.style.display = 'block';
+        }
+    }
+
+    function hidePreview() {
+        previewBox.style.display = 'none';
+        previewBox.innerHTML = '';
+    }
+
+    function movePreview(event) {
+        if (previewBox.style.display === 'block') {
+            previewBox.style.left = event.pageX + 20 + 'px';
+            previewBox.style.top = event.pageY + 20 + 'px';
+        }
+    }
+
+    document.querySelectorAll('.preview-link').forEach(function(link) {
+        link.addEventListener('mouseenter', showPreview);
+        link.addEventListener('mouseleave', hidePreview);
+        link.addEventListener('mousemove', movePreview);
+    });
+});
+

--- a/static/style.css
+++ b/static/style.css
@@ -611,3 +611,6 @@ th {
     margin-left: 10px;
 }
 
+#file-preview-box {
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}

--- a/templates/file_set_urls.html
+++ b/templates/file_set_urls.html
@@ -29,7 +29,7 @@
                 <td><a target=euid href=/euid_details?euid={{ ref.orig_file.euid }} >{{ ref.orig_file.euid }} </a></td>
                 <td>{{ ref.orig_file.json_addl.get('properties','').get('original_file_name') }} </td>
                 <td><a target=euid href=/euid_details?euid={{ ref.euid }}>{{ ref.euid }} </a></td>
-                <td><a href="{{ ref.url }}" target="_blank">{{ ref.url }}</a></td>
+                <td><a href="{{ ref.url }}" target="_blank" class="preview-link">{{ ref.url }}</a></td>
                 <td>{{ ref.start_datetime }}</td>
                 <td>{{ ref.end_datetime }}</td>
 
@@ -82,6 +82,7 @@
             document.body.removeChild(downloadLink);
         }
     </script>
+    <script src="static/preview.js"></script>
 
     <style>
         .floating-button {


### PR DESCRIPTION
## Summary
- add small popup preview for presigned file links
- include new script and CSS styling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: yaml, boto3)*

------
https://chatgpt.com/codex/tasks/task_e_6866cd5cb3f88331826ca2944df683fe