### PR TITLE
Add exploratory menu and patient views

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1461,6 +1461,47 @@ async def object_templates_summary(request: Request, _auth=Depends(require_auth)
     )
     return HTMLResponse(content=content)
 
+
+@app.get("/patient_views", response_class=HTMLResponse)
+async def patient_views(request: Request, patient_id: str = None, sort_by: str = "created", _auth=Depends(require_auth)):
+    bobdb = BloomObj(BLOOMdb3(app_username=request.session["user_data"]["email"]))
+
+    patient_euids = bobdb.search_objs_by_addl_metadata({}, True, btype="generic", b_sub_type="patient", super_type="actor")
+    patient_objs = [bobdb.get_by_euid(euid) for euid in patient_euids]
+    patient_ids = sorted({p.json_addl.get("properties", {}).get("patient_id") for p in patient_objs if p})
+
+    files = []
+    if patient_id:
+        search_criteria = {"properties": {"patient_id": patient_id}}
+        file_euids = bobdb.search_objs_by_addl_metadata(search_criteria, True, btype="file", super_type="file")
+        files = [bobdb.get_by_euid(euid) for euid in file_euids]
+        if sort_by == "record":
+            files.sort(key=lambda x: x.json_addl.get("properties", {}).get("record_datetime", "") or "")
+        else:
+            files.sort(key=lambda x: x.created_dt)
+
+    color_choices = ["#fbb4ae", "#b3cde3", "#ccebc5", "#decbe4", "#fed9a6"]
+    def purpose_color(val):
+        if not val:
+            return "#222"
+        return color_choices[hash(val) % len(color_choices)]
+
+    color_map = {f.euid: purpose_color(f.json_addl.get("properties", {}).get("purpose")) for f in files}
+
+    user_data = request.session.get("user_data", {})
+    style = {"skin_css": user_data.get("style_css", "static/skins/bloom.css")}
+
+    content = templates.get_template("patient_views.html").render(
+        request=request,
+        style=style,
+        udat=user_data,
+        patient_ids=patient_ids,
+        patient_id=patient_id,
+        files=files,
+        color_map=color_map,
+    )
+    return HTMLResponse(content=content)
+
 # Quick hack to allow the details page to display deleted items.  Need to rework how the rest of the system juggles this.
 @app.get("/euid_details")
 async def euid_details(

--- a/static/style.css
+++ b/static/style.css
@@ -150,6 +150,10 @@ button:hover {
 .admin-button {
     background-color: var(--accent-color);
 }
+
+.exploratory-button {
+    background-color: var(--addl-button-color);
+}
     
 form {
     padding: 0px;

--- a/templates/index2.html
+++ b/templates/index2.html
@@ -24,6 +24,14 @@
     <a class="idx_button_title navigate-button main-button" href="/serve_endpoint">Navigate Data Directories</a>
 </div>
 <hr>
+<div class="idx_section exploratory-section">
+    <a class="idx_button_title exploratory-button main-button" href="#">EXPLORATORY</a>
+    <div class="idx_subbuttons">
+        <a class="idx_button" href="/dindex2">Graph Viewer</a>
+        <a class="idx_button" href="/patient_views">Patient Views</a>
+    </div>
+</div>
+<hr>
 <div class="idx_section admin-section">
     <a class="idx_button_title admin-button main-button" href="/admin">ADMIN</a>
     <a href="/lims" style="display:none"></a>

--- a/templates/patient_views.html
+++ b/templates/patient_views.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" type="text/css" href="{{ style.skin_css }}">
+    <link rel="stylesheet" type="text/css" href="static/style.css">
+    {% set page_title = 'Patient Views' %}
+    <title>{{ page_title }}</title>
+    {% set bloom_mod = 'exploratory' %}
+</head>
+<body>
+    {% include 'bloom_header.html' %}
+    <small><a href="dindex2">(graph)</a></small> <small><a href="/">(B)</a></small>
+
+    <h1>Patient Views</h1>
+    <form method="get" action="/patient_views">
+        <label for="patient_id">Select Patient:</label>
+        <select name="patient_id" id="patient_id" onchange="this.form.submit()">
+            <option value="">-- choose --</option>
+            {% for pid in patient_ids %}
+            <option value="{{ pid }}" {% if pid == patient_id %}selected{% endif %}>{{ pid }}</option>
+            {% endfor %}
+        </select>
+        <noscript><button type="submit">Go</button></noscript>
+    </form>
+
+    {% if patient_id %}
+    <h2>Files for {{ patient_id }}</h2>
+    <div>
+        Sort:
+        <a href="?patient_id={{ patient_id }}&sort_by=created">by db creation</a> |
+        <a href="?patient_id={{ patient_id }}&sort_by=record">by record start</a>
+    </div>
+    <table>
+        <tr><th>EUID</th><th>Created</th><th>Record Start</th><th>Purpose</th></tr>
+        {% for file in files %}
+        <tr style="background-color: {{ color_map.get(file.euid, '#222') }};">
+            <td><a href="euid_details?euid={{ file.euid }}">{{ file.euid }}</a></td>
+            <td>{{ file.created_dt.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+            <td>{{ file.json_addl['properties'].get('record_datetime','') }}</td>
+            <td>{{ file.json_addl['properties'].get('purpose','') }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend index2 menu with an exploratory section
- style the new exploratory button
- add patient views template for reviewing files by patient
- implement `/patient_views` endpoint with basic sorting and coloring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: yaml, boto3)*

------
https://chatgpt.com/codex/tasks/task_e_6866d56f93c08331b63ccfa8b29cbdce