### PR TITLE
Keep file preview popups until user clicks outside

### DIFF
--- a/static/preview.js
+++ b/static/preview.js
@@ -95,11 +95,27 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    document.querySelectorAll('a[href*="euid_details?euid=FI"]').forEach(link => {
+    let currentLink = null;
 
-        link.addEventListener('mouseenter', showPreview);
-        link.addEventListener('mouseleave', hidePreview);
+    document.querySelectorAll('a[href*="euid_details?euid=FI"]').forEach(link => {
+        link.addEventListener('mouseenter', event => {
+            currentLink = event.currentTarget;
+            showPreview(event);
+        });
         link.addEventListener('mousemove', movePreview);
     });
+
+    // hide the preview when clicking outside of it and the originating link
+    document.addEventListener('click', event => {
+        if (previewBox.style.display === 'block') {
+            if (!previewBox.contains(event.target) && (!currentLink || !currentLink.contains(event.target))) {
+                hidePreview();
+                currentLink = null;
+            }
+        }
+    });
+
+    // prevent clicks inside the preview from bubbling up and closing it
+    previewBox.addEventListener('click', event => event.stopPropagation());
 });
 


### PR DESCRIPTION
## Summary
- stop closing image/PDF previews on hover out
- allow clicking inside preview and close only when clicking outside

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'zebra_day')*


------
https://chatgpt.com/codex/tasks/task_e_6866dd9ab624833195d2ab6a198b0145