### PR TITLE
Add timeline view to patient files

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1524,6 +1524,25 @@ async def patient_views(request: Request, patient_id: str = None, sort_by: str =
 
     color_map = {f.euid: purpose_color(f.json_addl.get("properties", {}).get("purpose")) for f in files}
 
+    files_data = []
+    for f in files:
+        props = f.json_addl.get("properties", {})
+        files_data.append({
+            "euid": f.euid,
+            "created": f.created_dt.strftime('%Y-%m-%d %H:%M:%S'),
+            "record_datetime": props.get("record_datetime", ""),
+            "purpose": props.get("purpose", ""),
+            "purpose_subtype": props.get("purpose_subtype", ""),
+            "category": props.get("category", ""),
+            "sub_category": props.get("sub_category", ""),
+            "sub_category_2": props.get("sub_category_2", ""),
+            "original_file_name": props.get("original_file_name", ""),
+            "clinician_id": props.get("clinician_id", ""),
+            "study_id": props.get("study_id", ""),
+            "lab_code": props.get("lab_code", ""),
+            "tags": props.get("file_tags", []),
+        })
+
     user_data = request.session.get("user_data", {})
     style = {"skin_css": user_data.get("style_css", "static/skins/bloom.css")}
 
@@ -1534,7 +1553,8 @@ async def patient_views(request: Request, patient_id: str = None, sort_by: str =
         patient_ids=patient_ids,
         patient_id=patient_id,
         files=files,
-        color_map=color_map
+        color_map=color_map,
+        files_data=files_data
     )
     return HTMLResponse(content=content)
 

--- a/static/patient_timeline.js
+++ b/static/patient_timeline.js
@@ -1,0 +1,86 @@
+// JavaScript for patient views timeline
+
+document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('toggle-view-btn');
+    if (!btn) return;
+
+    const tableView = document.getElementById('patient-table-view');
+    const timelineView = document.getElementById('timeline-view');
+
+    let showingTimeline = false;
+
+    const filesData = window.patientFilesData || [];
+    const colorMap = window.patientColorMap || {};
+
+    function buildTimeline() {
+        const tl = document.getElementById('timeline');
+        if (!tl) return;
+        tl.innerHTML = '';
+        const controls = document.getElementById('timeline-controls');
+        if (controls) controls.innerHTML = '';
+
+        const purposes = [...new Set(filesData.map(f => f.purpose))].filter(Boolean);
+        const activePurposes = new Set(purposes);
+
+        if (controls) {
+            controls.style.marginBottom = '10px';
+            purposes.forEach(p => {
+                const label = document.createElement('label');
+                label.style.marginRight = '10px';
+                const cb = document.createElement('input');
+                cb.type = 'checkbox';
+                cb.checked = true;
+                cb.addEventListener('change', () => {
+                    if (cb.checked) {
+                        activePurposes.add(p);
+                    } else {
+                        activePurposes.delete(p);
+                    }
+                    updateMarkers();
+                });
+                label.appendChild(cb);
+                label.append(' ' + p);
+                controls.appendChild(label);
+            });
+        }
+
+        function updateMarkers() {
+            tl.innerHTML = '';
+            const sorted = [...filesData].sort((a,b)=>new Date(a.record_datetime || a.created) - new Date(b.record_datetime || b.created));
+            sorted.forEach(file => {
+                if (file.purpose && !activePurposes.has(file.purpose)) return;
+                const link = document.createElement('a');
+                link.href = `euid_details?euid=${encodeURIComponent(file.euid)}`;
+                link.className = 'timeline-marker';
+                link.style.display = 'inline-block';
+                link.style.width = '16px';
+                link.style.height = '16px';
+                link.style.borderRadius = '50%';
+                link.style.backgroundColor = colorMap[file.euid] || '#777';
+                link.style.margin = '0 8px';
+                link.title = file.original_file_name || file.euid;
+                tl.appendChild(link);
+            });
+            // Re-init preview listeners for new anchors
+            if (window.initializePreviewLinks) {
+                window.initializePreviewLinks();
+            }
+        }
+
+        updateMarkers();
+    }
+
+    btn.addEventListener('click', () => {
+        showingTimeline = !showingTimeline;
+        if (showingTimeline) {
+            btn.textContent = 'Table View';
+            tableView.style.display = 'none';
+            timelineView.style.display = 'block';
+            buildTimeline();
+        } else {
+            btn.textContent = 'Timeline View';
+            timelineView.style.display = 'none';
+            tableView.style.display = 'block';
+        }
+    });
+});

--- a/static/preview.js
+++ b/static/preview.js
@@ -100,13 +100,19 @@ document.addEventListener('DOMContentLoaded', () => {
     let resizeInfo = null;
     const edgeSize = 8;
 
-    document.querySelectorAll('a[href*="euid_details?euid=FI"]').forEach(link => {
-        link.addEventListener('mouseenter', event => {
-            currentLink = event.currentTarget;
-            showPreview(event);
+    function attachPreviewLinks(root=document) {
+        root.querySelectorAll('a[href*="euid_details?euid=FI"]').forEach(link => {
+            link.addEventListener('mouseenter', event => {
+                currentLink = event.currentTarget;
+                showPreview(event);
+            });
+            link.addEventListener('mousemove', movePreview);
         });
-        link.addEventListener('mousemove', movePreview);
-    });
+    }
+
+    window.initializePreviewLinks = () => attachPreviewLinks(document);
+
+    attachPreviewLinks(document);
 
     // hide the preview when clicking outside of it and the originating link
     document.addEventListener('click', event => {

--- a/templates/patient_views.html
+++ b/templates/patient_views.html
@@ -31,18 +31,47 @@
         Sort:
         <a href="?patient_id={{ patient_id }}&sort_by=created">by db creation</a> |
         <a href="?patient_id={{ patient_id }}&sort_by=record">by record start</a>
+        <button id="toggle-view-btn" style="float:right;">Timeline View</button>
     </div>
+    <div id="patient-table-view">
     <table>
-        <tr><th>EUID</th><th>Created</th><th>Record Start</th><th>Purpose</th></tr>
+        <tr>
+            <th>EUID</th>
+            <th>Original Name</th>
+            <th>Clinician ID</th>
+            <th>Study ID</th>
+            <th>Lab Code</th>
+            <th>Tags</th>
+            <th>Created</th>
+            <th>Record Start</th>
+            <th>Purpose + Subtype</th>
+            <th>Category + SubCat1 + SubCat2</th>
+        </tr>
         {% for file in files %}
         <tr style="background-color: {{ color_map.get(file.euid, '#222') }};">
             <td><a href="euid_details?euid={{ file.euid }}">{{ file.euid }}</a></td>
+            <td>{{ file.json_addl['properties'].get('original_file_name','') }}</td>
+            <td>{{ file.json_addl['properties'].get('clinician_id','') }}</td>
+            <td>{{ file.json_addl['properties'].get('study_id','') }}</td>
+            <td>{{ file.json_addl['properties'].get('lab_code','') }}</td>
+            <td>{{ (file.json_addl['properties'].get('file_tags') or []) | join(', ') }}</td>
             <td>{{ file.created_dt.strftime('%Y-%m-%d %H:%M:%S') }}</td>
             <td>{{ file.json_addl['properties'].get('record_datetime','') }}</td>
-            <td>{{ file.json_addl['properties'].get('purpose','') }}</td>
+            <td>{{ file.json_addl['properties'].get('purpose','') }} {{ file.json_addl['properties'].get('purpose_subtype','') }}</td>
+            <td>{{ file.json_addl['properties'].get('category','') }} {{ file.json_addl['properties'].get('sub_category','') }} {{ file.json_addl['properties'].get('sub_category_2','') }}</td>
         </tr>
         {% endfor %}
     </table>
+    </div>
+    <div id="timeline-view" style="display:none;">
+        <div id="timeline-controls"></div>
+        <div id="timeline" style="overflow-x:auto; white-space:nowrap; padding-top:20px;"></div>
+    </div>
+    <script>
+        window.patientFilesData = {{ files_data | tojson | safe }};
+        window.patientColorMap = {{ color_map | tojson | safe }};
+    </script>
+    <script src="static/patient_timeline.js"></script>
     {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show extra metadata in patient preview table
- add a toggle button for timeline view
- implement timeline visualization and controls
- expose preview initialization helper to support dynamically added links

## Testing
- `pytest -q` *(fails: OperationalError connection to server at "localhost" port 5445 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6866e90985188331941f391ec36fbae9