### PR TITLE
Add glow to preview file links

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -377,6 +377,11 @@ a:active {
     color: var(--a-active); /* Change to your preferred color */
 }
 
+/* Links to file objects (with preview) have a subtle glow */
+a[href*="euid_details?euid=FI"] {
+    text-shadow: 0 0 5px var(--hilight-color);
+}
+
 .subtype-button {
     font-size: var(--font-size-xsmall);
     padding: 1px 2px;


### PR DESCRIPTION
## Summary
- style: add glow effect for links that provide file previews

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_6866eb189f90833191fce6e3d18ca3eb