### PR TITLE
Add sortable patient view table and improved timeline

### DIFF
--- a/static/patient_table.js
+++ b/static/patient_table.js
@@ -1,0 +1,43 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const table = document.getElementById('patient-table');
+    if (!table) return;
+    const tbody = table.tBodies[0];
+    const headers = table.querySelectorAll('th');
+    headers.forEach((th, idx) => {
+        th.style.cursor = 'pointer';
+        th.addEventListener('click', () => sortTable(idx, th));
+    });
+
+    function sortTable(colIdx, th) {
+        const rows = Array.from(tbody.querySelectorAll('tr'));
+        const asc = th.dataset.asc === 'true';
+        rows.sort((a,b)=>{
+            const av = a.cells[colIdx].innerText.trim();
+            const bv = b.cells[colIdx].innerText.trim();
+            return av.localeCompare(bv, undefined, {numeric:true});
+        });
+        if (asc) rows.reverse();
+        tbody.innerHTML = '';
+        rows.forEach(r=>tbody.appendChild(r));
+        headers.forEach(h=>delete h.dataset.asc);
+        th.dataset.asc = (!asc).toString();
+    }
+
+    const downloadBtn = document.getElementById('download-tsv-btn');
+    if (downloadBtn) {
+        downloadBtn.addEventListener('click', () => {
+            const rows = Array.from(table.querySelectorAll('tr'));
+            const data = rows.map(r => Array.from(r.children).map(c=>c.innerText.trim().replace(/\s+/g,' ')).join('\t')).join('\n');
+            const blob = new Blob([data], {type:'text/tab-separated-values'});
+            const a = document.createElement('a');
+            a.href = URL.createObjectURL(blob);
+            const pid = window.currentPatientId || 'patient';
+            a.download = `dewey_patient_view_${pid}.tsv`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(a.href);
+        });
+    }
+});
+

--- a/static/patient_timeline.js
+++ b/static/patient_timeline.js
@@ -47,20 +47,59 @@ document.addEventListener('DOMContentLoaded', () => {
         function updateMarkers() {
             tl.innerHTML = '';
             const sorted = [...filesData].sort((a,b)=>new Date(a.record_datetime || a.created) - new Date(b.record_datetime || b.created));
+            const groups = {};
             sorted.forEach(file => {
                 if (file.purpose && !activePurposes.has(file.purpose)) return;
-                const link = document.createElement('a');
-                link.href = `euid_details?euid=${encodeURIComponent(file.euid)}`;
-                link.className = 'timeline-marker';
-                link.style.display = 'inline-block';
-                link.style.width = '16px';
-                link.style.height = '16px';
-                link.style.borderRadius = '50%';
-                link.style.backgroundColor = colorMap[file.euid] || '#777';
-                link.style.margin = '0 8px';
-                link.title = file.original_file_name || file.euid;
-                tl.appendChild(link);
+                const d = new Date(file.record_datetime || file.created);
+                const key = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-01`;
+                if (!groups[key]) groups[key] = [];
+                groups[key].push(file);
             });
+
+            Object.keys(groups).sort().forEach(key => {
+                const bin = document.createElement('div');
+                bin.style.display = 'inline-flex';
+                bin.style.flexDirection = 'column-reverse';
+                bin.style.alignItems = 'center';
+                bin.style.width = '60px';
+                bin.style.margin = '0 5px';
+
+                const label = document.createElement('div');
+                label.textContent = key;
+                label.style.fontSize = '10px';
+                bin.appendChild(label);
+
+                groups[key].forEach(file => {
+                    const wrapper = document.createElement('div');
+                    wrapper.style.display = 'flex';
+                    wrapper.style.flexDirection = 'column';
+                    wrapper.style.alignItems = 'center';
+
+                    const fname = document.createElement('div');
+                    fname.textContent = file.original_file_name || file.euid;
+                    fname.style.fontSize = '9px';
+                    fname.style.transform = 'rotate(45deg)';
+                    fname.style.whiteSpace = 'nowrap';
+                    wrapper.appendChild(fname);
+
+                    const link = document.createElement('a');
+                    link.href = `euid_details?euid=${encodeURIComponent(file.euid)}`;
+                    link.className = 'timeline-marker';
+                    link.style.display = 'block';
+                    link.style.width = '12px';
+                    link.style.height = '12px';
+                    link.style.borderRadius = '50%';
+                    link.style.backgroundColor = colorMap[file.euid] || '#777';
+                    link.style.marginTop = '3px';
+                    link.title = file.original_file_name || file.euid;
+                    wrapper.appendChild(link);
+
+                    bin.appendChild(wrapper);
+                });
+
+                tl.appendChild(bin);
+            });
+
             // Re-init preview listeners for new anchors
             if (window.initializePreviewLinks) {
                 window.initializePreviewLinks();

--- a/templates/patient_views.html
+++ b/templates/patient_views.html
@@ -34,7 +34,8 @@
         <button id="toggle-view-btn" style="float:right;">Timeline View</button>
     </div>
     <div id="patient-table-view">
-    <table>
+    <button id="download-tsv-btn" style="margin-bottom:5px;">Download TSV</button>
+    <table id="patient-table">
         <tr>
             <th>EUID</th>
             <th>Original Name</th>
@@ -70,7 +71,9 @@
     <script>
         window.patientFilesData = {{ files_data | tojson | safe }};
         window.patientColorMap = {{ color_map | tojson | safe }};
+        window.currentPatientId = {{ patient_id | tojson | safe }};
     </script>
+    <script src="static/patient_table.js"></script>
     <script src="static/patient_timeline.js"></script>
     {% endif %}
 </body>


### PR DESCRIPTION
## Summary
- make patient view table sortable on the client
- allow TSV download of patient view table
- display patient timeline grouped by month with stacked markers and filenames

## Testing
- `pytest -q` *(fails: psycopg2 OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_6866ecca0100833186caf5a93503e95f