### PR TITLE
Update preview glow logic

### DIFF
--- a/static/preview.js
+++ b/static/preview.js
@@ -110,8 +110,22 @@ document.addEventListener('DOMContentLoaded', () => {
     let resizeInfo = null;
     const edgeSize = 8;
 
+    function markPreviewable(link) {
+        if (link.dataset.previewChecked) return;
+        link.dataset.previewChecked = '1';
+        const u = new URL(link.href);
+        const euid = u.searchParams.get('euid');
+        if (!euid) return;
+        fetchProperty(euid, 'file_type').then(type => {
+            if (type && allowed.has(type.toLowerCase())) {
+                link.classList.add('previewable');
+            }
+        }).catch(() => {});
+    }
+
     function attachPreviewLinks(root=document) {
         root.querySelectorAll('a[href*="euid_details?euid=FI"]').forEach(link => {
+            markPreviewable(link);
             link.addEventListener('mouseenter', event => {
                 currentLink = event.currentTarget;
                 showPreview(event);

--- a/static/style.css
+++ b/static/style.css
@@ -377,9 +377,9 @@ a:active {
     color: var(--a-active); /* Change to your preferred color */
 }
 
-/* Links to file objects (with preview) have a subtle glow */
-a[href*="euid_details?euid=FI"] {
-    text-shadow: 0 0 5px var(--hilight-color);
+/* Links to previewable file objects have a glow */
+a.previewable {
+    text-shadow: -18px -8px 18px #fbeeed;
 }
 
 .subtype-button {


### PR DESCRIPTION
## Summary
- adjust CSS for previewable file links
- mark previewable file links in JS and apply glow effect

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6866edf333f48331854cf8228cc56157