### PR TITLE
Enhance patient table sorting and timeline view

### DIFF
--- a/static/patient_table.js
+++ b/static/patient_table.js
@@ -1,26 +1,69 @@
 document.addEventListener('DOMContentLoaded', () => {
     const table = document.getElementById('patient-table');
     if (!table) return;
-    const tbody = table.tBodies[0];
+    const tbody = table.querySelector('tbody');
     const headers = table.querySelectorAll('th');
+    let currentCol = 0;
+    let colorized = false;
+    const colorBtn = document.getElementById('colorize-toggle');
+    const palette = ['#fbb4ae', '#b3cde3', '#ccebc5', '#decbe4', '#fed9a6', '#ffffcc', '#e5d8bd', '#f2f2f2'];
+
+    const allRows = Array.from(tbody.querySelectorAll('tr'));
+    allRows.forEach(r => r.dataset.origColor = r.style.backgroundColor);
+
     headers.forEach((th, idx) => {
         th.style.cursor = 'pointer';
-        th.addEventListener('click', () => sortTable(idx, th));
+        th.addEventListener('click', () => {
+            sortTable(idx, th);
+            if (colorized) colorizeByColumn(idx);
+        });
     });
 
     function sortTable(colIdx, th) {
+        currentCol = colIdx;
         const rows = Array.from(tbody.querySelectorAll('tr'));
         const asc = th.dataset.asc === 'true';
+        const isNumeric = rows.every(r => !isNaN(parseFloat(r.cells[colIdx].innerText.trim())));
         rows.sort((a,b)=>{
             const av = a.cells[colIdx].innerText.trim();
             const bv = b.cells[colIdx].innerText.trim();
-            return av.localeCompare(bv, undefined, {numeric:true});
+            if (isNumeric) {
+                return parseFloat(av) - parseFloat(bv);
+            }
+            return av.localeCompare(bv, undefined, {numeric:true, sensitivity:'base'});
         });
         if (asc) rows.reverse();
         tbody.innerHTML = '';
         rows.forEach(r=>tbody.appendChild(r));
         headers.forEach(h=>delete h.dataset.asc);
         th.dataset.asc = (!asc).toString();
+    }
+
+    function colorizeByColumn(colIdx) {
+        const rows = Array.from(tbody.querySelectorAll('tr'));
+        const colors = {};
+        let i = 0;
+        rows.forEach(r => {
+            const val = r.cells[colIdx].innerText.trim();
+            if (!colors[val]) {
+                colors[val] = palette[i % palette.length];
+                i++;
+            }
+            r.style.backgroundColor = colors[val];
+        });
+    }
+
+    if (colorBtn) {
+        colorBtn.addEventListener('click', () => {
+            colorized = !colorized;
+            if (colorized) {
+                colorizeByColumn(currentCol);
+                colorBtn.textContent = 'Uncolorize';
+            } else {
+                allRows.forEach(r => r.style.backgroundColor = r.dataset.origColor || '');
+                colorBtn.textContent = 'Colorize';
+            }
+        });
     }
 
     const downloadBtn = document.getElementById('download-tsv-btn');

--- a/static/patient_timeline.js
+++ b/static/patient_timeline.js
@@ -19,12 +19,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const controls = document.getElementById('timeline-controls');
         if (controls) controls.innerHTML = '';
 
-        const purposes = [...new Set(filesData.map(f => f.purpose))].filter(Boolean);
-        const activePurposes = new Set(purposes);
+        const purposeCombos = [...new Set(filesData.map(f => `${f.purpose || ''} ${f.purpose_subtype || ''}`.trim()))].filter(Boolean);
+        const categoryCombos = [...new Set(filesData.map(f => `${f.category || ''} ${f.sub_category || ''} ${f.sub_category_2 || ''}`.trim()))].filter(Boolean);
+        const activePurposes = new Set(purposeCombos);
+        const activeCategories = new Set(categoryCombos);
 
         if (controls) {
             controls.style.marginBottom = '10px';
-            purposes.forEach(p => {
+            purposeCombos.forEach(p => {
                 const label = document.createElement('label');
                 label.style.marginRight = '10px';
                 const cb = document.createElement('input');
@@ -42,6 +44,25 @@ document.addEventListener('DOMContentLoaded', () => {
                 label.append(' ' + p);
                 controls.appendChild(label);
             });
+            controls.appendChild(document.createElement('br'));
+            categoryCombos.forEach(c => {
+                const label = document.createElement('label');
+                label.style.marginRight = '10px';
+                const cb = document.createElement('input');
+                cb.type = 'checkbox';
+                cb.checked = true;
+                cb.addEventListener('change', () => {
+                    if (cb.checked) {
+                        activeCategories.add(c);
+                    } else {
+                        activeCategories.delete(c);
+                    }
+                    updateMarkers();
+                });
+                label.appendChild(cb);
+                label.append(' ' + c);
+                controls.appendChild(label);
+            });
         }
 
         function updateMarkers() {
@@ -49,7 +70,10 @@ document.addEventListener('DOMContentLoaded', () => {
             const sorted = [...filesData].sort((a,b)=>new Date(a.record_datetime || a.created) - new Date(b.record_datetime || b.created));
             const groups = {};
             sorted.forEach(file => {
-                if (file.purpose && !activePurposes.has(file.purpose)) return;
+                const pCombo = `${file.purpose || ''} ${file.purpose_subtype || ''}`.trim();
+                const cCombo = `${file.category || ''} ${file.sub_category || ''} ${file.sub_category_2 || ''}`.trim();
+                if (pCombo && !activePurposes.has(pCombo)) return;
+                if (cCombo && !activeCategories.has(cCombo)) return;
                 const d = new Date(file.record_datetime || file.created);
                 const key = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-01`;
                 if (!groups[key]) groups[key] = [];
@@ -66,7 +90,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 const label = document.createElement('div');
                 label.textContent = key;
-                label.style.fontSize = '10px';
+                label.style.fontSize = '14px';
+                label.style.fontWeight = 'bold';
+                label.style.marginTop = '20px';
                 bin.appendChild(label);
 
                 groups[key].forEach(file => {

--- a/templates/patient_views.html
+++ b/templates/patient_views.html
@@ -35,7 +35,9 @@
     </div>
     <div id="patient-table-view">
     <button id="download-tsv-btn" style="margin-bottom:5px;">Download TSV</button>
+    <button id="colorize-toggle" style="margin-bottom:5px;">Colorize</button>
     <table id="patient-table">
+        <thead>
         <tr>
             <th>EUID</th>
             <th>Original Name</th>
@@ -48,6 +50,8 @@
             <th>Purpose + Subtype</th>
             <th>Category + SubCat1 + SubCat2</th>
         </tr>
+        </thead>
+        <tbody>
         {% for file in files %}
         <tr style="background-color: {{ color_map.get(file.euid, '#222') }};">
             <td><a href="euid_details?euid={{ file.euid }}">{{ file.euid }}</a></td>
@@ -62,6 +66,7 @@
             <td>{{ file.json_addl['properties'].get('category','') }} {{ file.json_addl['properties'].get('sub_category','') }} {{ file.json_addl['properties'].get('sub_category_2','') }}</td>
         </tr>
         {% endfor %}
+        </tbody>
     </table>
     </div>
     <div id="timeline-view" style="display:none;">


### PR DESCRIPTION
## Summary
- keep patient view header fixed when sorting
- add row colorizing toggle and improved numeric sort handling
- enlarge and style timeline axis labels
- provide purpose/subtype and category combo checkboxes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'zebra_day')*

------
https://chatgpt.com/codex/tasks/task_e_6866f30126c0833185e5fa6435ea3397