### PR TITLE
feat: Implement Subject vs Object refactor

### DIFF
--- a/bloom_lims/config/action/core.json
+++ b/bloom_lims/config/action/core.json
@@ -77,5 +77,29 @@
         "description": "Add Parent or Child Relationships (aka lineages)."
       }
     }
+  },
+  "create-subject-and-anchor": {
+    "1.0": {
+      "action_template": {
+        "action_name": "Create Subject (Decision Scope)",
+        "method_name": "do_action_create_subject_and_anchor",
+        "action_executed": "0",
+        "max_executions": "-1",
+        "action_enabled": "1",
+        "capture_data": "yes",
+        "captured_data": {
+          "_subject_kind": "Subject Kind: <select required name=&quot;subject_kind&quot;><option value=&quot;accession&quot;>Accession</option><option value=&quot;analysis_bundle&quot;>Analysis Bundle</option><option value=&quot;report&quot;>Report</option><option value=&quot;generic&quot;>Generic</option></select>",
+          "_subject_name": "Subject Name (optional): <input type=&quot;text&quot; name=&quot;subject_name&quot; value=&quot;&quot;/>",
+          "_comments": "Comments: <textarea name=&quot;comments&quot;></textarea>"
+        },
+        "deactivate_actions_when_executed": [],
+        "executed_datetime": [],
+        "action_order": "0",
+        "action_simple_value": "",
+        "action_user": [],
+        "curr_user": "",
+        "description": "Create a Subject (decision scope) with this object as the anchor."
+      }
+    }
   }
 }

--- a/bloom_lims/config/subject/generic.json
+++ b/bloom_lims/config/subject/generic.json
@@ -1,0 +1,187 @@
+{
+  "accession-subject": {
+    "1.0": {
+      "description": "Decision scope for an accession (ACC / TRX / intake bundle).",
+      "properties": {
+        "name": "",
+        "comments": "",
+        "lab_code": "",
+        "subject_kind": "accession",
+        "subject_key": "",
+        "anchor_euid": "",
+        "status": "active"
+      },
+      "ui_form_properties": [
+        {"property_key": "subject_kind", "form_label": "Subject Kind", "required": true, "value_type": "controlled"},
+        {"property_key": "anchor_euid", "form_label": "Anchor EUID", "required": true, "value_type": "uid-interactive"},
+        {"property_key": "subject_key", "form_label": "Subject Key", "required": true, "value_type": "string"},
+        {"property_key": "status", "form_label": "Status", "required": true, "value_type": "controlled"},
+        {"property_key": "name", "form_label": "Name", "required": false, "value_type": "string"},
+        {"property_key": "comments", "form_label": "Comments", "required": false, "value_type": "text"}
+      ],
+      "controlled_properties": {
+        "subject_kind": {"type": "string", "enum": ["accession"]},
+        "status": {"type": "string", "enum": ["active", "retired"]}
+      },
+      "expected_inputs": [],
+      "expected_outputs": [],
+      "instantiation_layouts": [],
+      "cogs": {
+        "state": "inactive",
+        "cost": "0.00",
+        "cost_split_by_children": [{"*/*/*/*": {}}],
+        "allocation_type": ""
+      },
+      "singleton": "0",
+      "action_groups": {},
+      "action_imports": {
+        "core": {
+          "group_order": "1",
+          "group_name": "Core Actions",
+          "actions": {
+            "action/core/*/1.0/": {}
+          }
+        }
+      }
+    }
+  },
+  "analysis-bundle-subject": {
+    "1.0": {
+      "description": "Decision scope for analysis result bundles.",
+      "properties": {
+        "name": "",
+        "comments": "",
+        "lab_code": "",
+        "subject_kind": "analysis_bundle",
+        "subject_key": "",
+        "anchor_euid": "",
+        "status": "active"
+      },
+      "ui_form_properties": [
+        {"property_key": "subject_kind", "form_label": "Subject Kind", "required": true, "value_type": "controlled"},
+        {"property_key": "anchor_euid", "form_label": "Anchor EUID", "required": true, "value_type": "uid-interactive"},
+        {"property_key": "subject_key", "form_label": "Subject Key", "required": true, "value_type": "string"},
+        {"property_key": "status", "form_label": "Status", "required": true, "value_type": "controlled"},
+        {"property_key": "name", "form_label": "Name", "required": false, "value_type": "string"},
+        {"property_key": "comments", "form_label": "Comments", "required": false, "value_type": "text"}
+      ],
+      "controlled_properties": {
+        "subject_kind": {"type": "string", "enum": ["analysis_bundle"]},
+        "status": {"type": "string", "enum": ["active", "retired"]}
+      },
+      "expected_inputs": [],
+      "expected_outputs": [],
+      "instantiation_layouts": [],
+      "cogs": {
+        "state": "inactive",
+        "cost": "0.00",
+        "cost_split_by_children": [{"*/*/*/*": {}}],
+        "allocation_type": ""
+      },
+      "singleton": "0",
+      "action_groups": {},
+      "action_imports": {
+        "core": {
+          "group_order": "1",
+          "group_name": "Core Actions",
+          "actions": {
+            "action/core/*/1.0/": {}
+          }
+        }
+      }
+    }
+  },
+  "report-subject": {
+    "1.0": {
+      "description": "Decision scope for clinical reportable units.",
+      "properties": {
+        "name": "",
+        "comments": "",
+        "lab_code": "",
+        "subject_kind": "report",
+        "subject_key": "",
+        "anchor_euid": "",
+        "status": "active"
+      },
+      "ui_form_properties": [
+        {"property_key": "subject_kind", "form_label": "Subject Kind", "required": true, "value_type": "controlled"},
+        {"property_key": "anchor_euid", "form_label": "Anchor EUID", "required": true, "value_type": "uid-interactive"},
+        {"property_key": "subject_key", "form_label": "Subject Key", "required": true, "value_type": "string"},
+        {"property_key": "status", "form_label": "Status", "required": true, "value_type": "controlled"},
+        {"property_key": "name", "form_label": "Name", "required": false, "value_type": "string"},
+        {"property_key": "comments", "form_label": "Comments", "required": false, "value_type": "text"}
+      ],
+      "controlled_properties": {
+        "subject_kind": {"type": "string", "enum": ["report"]},
+        "status": {"type": "string", "enum": ["active", "retired"]}
+      },
+      "expected_inputs": [],
+      "expected_outputs": [],
+      "instantiation_layouts": [],
+      "cogs": {
+        "state": "inactive",
+        "cost": "0.00",
+        "cost_split_by_children": [{"*/*/*/*": {}}],
+        "allocation_type": ""
+      },
+      "singleton": "0",
+      "action_groups": {},
+      "action_imports": {
+        "core": {
+          "group_order": "1",
+          "group_name": "Core Actions",
+          "actions": {
+            "action/core/*/1.0/": {}
+          }
+        }
+      }
+    }
+  },
+  "generic-subject": {
+    "1.0": {
+      "description": "Fallback decision scope for custom use cases.",
+      "properties": {
+        "name": "",
+        "comments": "",
+        "lab_code": "",
+        "subject_kind": "generic",
+        "subject_key": "",
+        "anchor_euid": "",
+        "status": "active"
+      },
+      "ui_form_properties": [
+        {"property_key": "subject_kind", "form_label": "Subject Kind", "required": true, "value_type": "controlled"},
+        {"property_key": "anchor_euid", "form_label": "Anchor EUID", "required": true, "value_type": "uid-interactive"},
+        {"property_key": "subject_key", "form_label": "Subject Key", "required": true, "value_type": "string"},
+        {"property_key": "status", "form_label": "Status", "required": true, "value_type": "controlled"},
+        {"property_key": "name", "form_label": "Name", "required": false, "value_type": "string"},
+        {"property_key": "comments", "form_label": "Comments", "required": false, "value_type": "text"}
+      ],
+      "controlled_properties": {
+        "subject_kind": {"type": "string", "enum": ["generic", "accession", "analysis_bundle", "report"]},
+        "status": {"type": "string", "enum": ["active", "retired"]}
+      },
+      "expected_inputs": [],
+      "expected_outputs": [],
+      "instantiation_layouts": [],
+      "cogs": {
+        "state": "inactive",
+        "cost": "0.00",
+        "cost_split_by_children": [{"*/*/*/*": {}}],
+        "allocation_type": ""
+      },
+      "singleton": "0",
+      "action_groups": {},
+      "action_imports": {
+        "core": {
+          "group_order": "1",
+          "group_name": "Core Actions",
+          "actions": {
+            "action/core/*/1.0/": {}
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/bloom_lims/config/subject/metadata.json
+++ b/bloom_lims/config/subject/metadata.json
@@ -1,0 +1,6 @@
+{
+  "euid_prefixes": {
+    "default": "SX"
+  }
+}
+

--- a/bloom_lims/db.py
+++ b/bloom_lims/db.py
@@ -573,6 +573,22 @@ class file_instance_lineage(generic_instance_lineage):
     }
 
 
+class subject_template(generic_template):
+    __mapper_args__ = {
+        "polymorphic_identity": "subject_template",
+    }
+
+class subject_instance(generic_instance):
+    __mapper_args__ = {
+        "polymorphic_identity": "subject_instance",
+    }
+
+class subject_instance_lineage(generic_instance_lineage):
+    __mapper_args__ = {
+        "polymorphic_identity": "subject_instance_lineage",
+    }
+
+
 class BLOOMdb3:
     """
     BLOOM LIMS Database Connection Manager.
@@ -729,6 +745,9 @@ class BLOOMdb3:
             health_event_template,
             health_event_instance,
             health_event_instance_lineage,
+            subject_template,
+            subject_instance,
+            subject_instance_lineage,
         ]
         for cls in classes_to_register:
             class_name = cls.__name__

--- a/bloom_lims/env/postgres_schema_v3.sql
+++ b/bloom_lims/env/postgres_schema_v3.sql
@@ -119,6 +119,7 @@ CREATE SEQUENCE fx_instance_seq;
 CREATE SEQUENCE fi_instance_seq;
 CREATE SEQUENCE fs_instance_seq;
 CREATE SEQUENCE ev_instance_seq;
+CREATE SEQUENCE sx_instance_seq;
 
 CREATE TABLE generic_instance (
     uuid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -188,6 +189,7 @@ BEGIN
             WHEN prefix = 'FI' THEN nextval('fi_instance_seq')
             WHEN prefix = 'FS' THEN nextval('fs_instance_seq')
             WHEN prefix = 'EV' THEN nextval('ev_instance_seq')
+            WHEN prefix = 'SX' THEN nextval('sx_instance_seq')
 
             -- Add more cases for other prefixes
             ELSE nextval('generic_instance_seq') -- Default sequence

--- a/bloom_lims/subjecting.py
+++ b/bloom_lims/subjecting.py
@@ -1,0 +1,360 @@
+"""
+BLOOM LIMS - Subject Management Module
+
+This module provides helper functions for managing Subjects in BLOOM LIMS.
+Subjects are logical aggregates that decisions apply to, spanning multiple objects.
+
+Key concepts:
+- Object (fact): A concrete thing (sample, container, fileset, etc.)
+- Subject (decision scope): A logical aggregate that decisions apply to
+- Anchor: The primary object that defines the subject
+- Members: Additional objects associated with the subject
+
+Relationship types:
+- subject_anchor: Subject → Primary anchor object
+- subject_member: Subject → Member/evidence objects
+"""
+
+import logging
+from typing import Optional, List, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+# Relationship type constants
+RELATIONSHIP_SUBJECT_ANCHOR = "subject_anchor"
+RELATIONSHIP_SUBJECT_MEMBER = "subject_member"
+
+# Template mapping for subject kinds
+SUBJECT_TEMPLATE_MAP = {
+    "accession": "subject/generic/accession-subject/1.0",
+    "analysis_bundle": "subject/generic/analysis-bundle-subject/1.0",
+    "report": "subject/generic/report-subject/1.0",
+    "generic": "subject/generic/generic-subject/1.0",
+}
+
+
+def generate_subject_key(subject_kind: str, anchor_euid: str) -> str:
+    """
+    Generate a stable, deterministic subject key.
+    
+    Args:
+        subject_kind: The kind of subject (accession, analysis_bundle, report, generic)
+        anchor_euid: The EUID of the anchor object
+        
+    Returns:
+        A stable subject key in format "{subject_kind}:{anchor_euid}"
+    """
+    return f"{subject_kind}:{anchor_euid}"
+
+
+def find_subject_by_key(bob, subject_key: str):
+    """
+    Find a subject by its stable subject_key.
+    
+    Args:
+        bob: BloomObj instance
+        subject_key: The subject_key to search for
+        
+    Returns:
+        The subject instance if found, None otherwise
+    """
+    try:
+        results = bob.session.query(bob.Base.classes.generic_instance).filter(
+            bob.Base.classes.generic_instance.super_type == "subject",
+            bob.Base.classes.generic_instance.is_deleted == False,
+        ).all()
+        
+        for result in results:
+            props = result.json_addl.get("properties", {})
+            if props.get("subject_key") == subject_key:
+                return result
+        
+        return None
+    except Exception as e:
+        logger.error(f"Error finding subject by key {subject_key}: {e}")
+        return None
+
+
+def get_subject_template_euid(bob, subject_kind: str) -> Optional[str]:
+    """
+    Get the template EUID for a given subject kind.
+    
+    Args:
+        bob: BloomObj instance
+        subject_kind: The kind of subject
+        
+    Returns:
+        The template EUID if found, None otherwise
+    """
+    template_path = SUBJECT_TEMPLATE_MAP.get(subject_kind, SUBJECT_TEMPLATE_MAP["generic"])
+    parts = template_path.split("/")
+    if len(parts) != 4:
+        logger.error(f"Invalid template path: {template_path}")
+        return None
+    
+    super_type, btype, b_sub_type, version = parts
+    
+    try:
+        templates = bob.query_template_by_component_v2(
+            super_type=super_type,
+            btype=btype,
+            b_sub_type=b_sub_type,
+            version=version
+        )
+        if templates:
+            return templates[0].euid
+        return None
+    except Exception as e:
+        logger.error(f"Error getting subject template: {e}")
+        return None
+
+
+def create_subject(
+    bob,
+    anchor_euid: str,
+    subject_kind: str,
+    subject_key: Optional[str] = None,
+    extra_props: Dict[str, Any] = None,
+    template_euid: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Create or find existing subject. Idempotent - returns existing if found.
+    
+    Args:
+        bob: BloomObj instance
+        anchor_euid: EUID of the anchor object
+        subject_kind: Kind of subject (accession, analysis_bundle, report, generic)
+        subject_key: Optional custom subject key. Defaults to "{subject_kind}:{anchor_euid}"
+        extra_props: Additional properties to set on the subject
+        template_euid: Optional template EUID override
+        
+    Returns:
+        Subject EUID if successful, None otherwise
+    """
+    if extra_props is None:
+        extra_props = {}
+    
+    # Generate subject_key if not provided
+    if subject_key is None:
+        subject_key = generate_subject_key(subject_kind, anchor_euid)
+    
+    # Check for existing subject (idempotency)
+    existing = find_subject_by_key(bob, subject_key)
+    if existing:
+        logger.info(f"Subject already exists with key {subject_key}: {existing.euid}")
+        return existing.euid
+    
+    # Get or validate template
+    if template_euid is None:
+        template_euid = get_subject_template_euid(bob, subject_kind)
+    
+    if template_euid is None:
+        logger.error(f"No template found for subject kind: {subject_kind}")
+        return None
+    
+    try:
+        # Create the subject instance
+        result = bob.create_instances(template_euid)
+        if not result or not result[0]:
+            logger.error("Failed to create subject instance")
+            return None
+
+        subject = result[0][0]
+
+        # Update properties
+        props = subject.json_addl.get("properties", {})
+        props["subject_kind"] = subject_kind
+        props["subject_key"] = subject_key
+        props["anchor_euid"] = anchor_euid
+        props["status"] = extra_props.get("status", "active")
+        props["name"] = extra_props.get("name", f"Subject: {subject_key}")
+
+        # Merge extra properties
+        for key, value in extra_props.items():
+            if key not in ["subject_kind", "subject_key", "anchor_euid"]:
+                props[key] = value
+
+        subject.json_addl["properties"] = props
+        from sqlalchemy.orm.attributes import flag_modified
+        flag_modified(subject, "json_addl")
+
+        bob.session.commit()
+
+        # Create anchor relationship
+        link_subject_anchor(bob, subject.euid, anchor_euid)
+
+        logger.info(f"Created subject {subject.euid} with key {subject_key}")
+        return subject.euid
+
+    except Exception as e:
+        logger.error(f"Error creating subject: {e}")
+        bob.session.rollback()
+        return None
+
+
+def link_subject_anchor(bob, subject_euid: str, anchor_euid: str) -> bool:
+    """
+    Create subject → anchor relationship edge.
+
+    Args:
+        bob: BloomObj instance
+        subject_euid: EUID of the subject
+        anchor_euid: EUID of the anchor object
+
+    Returns:
+        True if successful, False otherwise
+    """
+    try:
+        # Check if relationship already exists
+        subject = bob.get_by_euid(subject_euid)
+        for lineage in subject.parent_of_lineages:
+            if lineage.is_deleted:
+                continue
+            if (lineage.child_instance.euid == anchor_euid and
+                lineage.relationship_type == RELATIONSHIP_SUBJECT_ANCHOR):
+                logger.info(f"Anchor relationship already exists: {subject_euid} -> {anchor_euid}")
+                return True
+
+        bob.create_generic_instance_lineage_by_euids(
+            subject_euid,
+            anchor_euid,
+            relationship_type=RELATIONSHIP_SUBJECT_ANCHOR
+        )
+        bob.session.commit()
+        logger.info(f"Created anchor relationship: {subject_euid} -> {anchor_euid}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Error creating anchor relationship: {e}")
+        bob.session.rollback()
+        return False
+
+
+def add_subject_members(bob, subject_euid: str, member_euids: List[str]) -> Dict[str, bool]:
+    """
+    Add subject → member relationship edges.
+
+    Args:
+        bob: BloomObj instance
+        subject_euid: EUID of the subject
+        member_euids: List of member object EUIDs
+
+    Returns:
+        Dict mapping member EUIDs to success status
+    """
+    results = {}
+    subject = bob.get_by_euid(subject_euid)
+
+    # Get existing member relationships
+    existing_members = set()
+    for lineage in subject.parent_of_lineages:
+        if lineage.is_deleted:
+            continue
+        if lineage.relationship_type == RELATIONSHIP_SUBJECT_MEMBER:
+            existing_members.add(lineage.child_instance.euid)
+
+    for member_euid in member_euids:
+        try:
+            if member_euid in existing_members:
+                logger.info(f"Member relationship already exists: {subject_euid} -> {member_euid}")
+                results[member_euid] = True
+                continue
+
+            bob.create_generic_instance_lineage_by_euids(
+                subject_euid,
+                member_euid,
+                relationship_type=RELATIONSHIP_SUBJECT_MEMBER
+            )
+            results[member_euid] = True
+            logger.info(f"Created member relationship: {subject_euid} -> {member_euid}")
+
+        except Exception as e:
+            logger.error(f"Error adding member {member_euid}: {e}")
+            results[member_euid] = False
+
+    bob.session.commit()
+    return results
+
+
+def list_subjects_for_object(bob, object_euid: str) -> List[Dict[str, Any]]:
+    """
+    Find all subjects containing this object (as anchor or member).
+
+    Args:
+        bob: BloomObj instance
+        object_euid: EUID of the object
+
+    Returns:
+        List of dicts with subject info: {euid, kind, role, status, subject_key}
+    """
+    subjects = []
+    obj = bob.get_by_euid(object_euid)
+
+    if not obj:
+        return subjects
+
+    # Check child_of_lineages to find subjects where this object is a child
+    for lineage in obj.child_of_lineages:
+        if lineage.is_deleted:
+            continue
+
+        parent = lineage.parent_instance
+        if parent.super_type != "subject":
+            continue
+
+        role = "unknown"
+        if lineage.relationship_type == RELATIONSHIP_SUBJECT_ANCHOR:
+            role = "anchor"
+        elif lineage.relationship_type == RELATIONSHIP_SUBJECT_MEMBER:
+            role = "member"
+
+        props = parent.json_addl.get("properties", {})
+        subjects.append({
+            "euid": parent.euid,
+            "kind": props.get("subject_kind", "unknown"),
+            "role": role,
+            "status": props.get("status", "unknown"),
+            "subject_key": props.get("subject_key", ""),
+            "name": props.get("name", parent.name),
+        })
+
+    return subjects
+
+
+def list_members_for_subject(bob, subject_euid: str) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Return anchor and members for a subject.
+
+    Args:
+        bob: BloomObj instance
+        subject_euid: EUID of the subject
+
+    Returns:
+        Dict with keys 'anchor' and 'members', each containing list of object info
+    """
+    result = {"anchor": [], "members": []}
+    subject = bob.get_by_euid(subject_euid)
+
+    if not subject:
+        return result
+
+    for lineage in subject.parent_of_lineages:
+        if lineage.is_deleted:
+            continue
+
+        child = lineage.child_instance
+        obj_info = {
+            "euid": child.euid,
+            "name": child.json_addl.get("properties", {}).get("name", child.name),
+            "btype": child.btype,
+            "b_sub_type": child.b_sub_type,
+            "super_type": child.super_type,
+        }
+
+        if lineage.relationship_type == RELATIONSHIP_SUBJECT_ANCHOR:
+            result["anchor"].append(obj_info)
+        elif lineage.relationship_type == RELATIONSHIP_SUBJECT_MEMBER:
+            result["members"].append(obj_info)
+
+    return result
+

--- a/main.py
+++ b/main.py
@@ -1347,10 +1347,14 @@ async def euid_details(
             for column in obj.__table__.columns
             if hasattr(obj, column.key)
         }
-        obj_dict["parent_template_euid"] = obj.parent_template.euid if hasattr(obj, "parent_template") else ""  
+        obj_dict["parent_template_euid"] = obj.parent_template.euid if hasattr(obj, "parent_template") else ""
         audit_logs = bobdb.query_audit_log_by_euid(euid)
         user_data = request.session.get("user_data", {})
         style = {"skin_css": user_data.get("style_css", "static/skins/bloom.css")}
+
+        # Get subjects for this object
+        from bloom_lims.subjecting import list_subjects_for_object
+        subjects_for_object = list_subjects_for_object(bobdb, euid)
 
         content = templates.get_template("euid_details.html").render(
             request=request,
@@ -1362,6 +1366,7 @@ async def euid_details(
             audit_logs=audit_logs,
             oobj=obj,
             udat=request.session["user_data"],
+            subjects_for_object=subjects_for_object,
         )
         return HTMLResponse(content=content)
 

--- a/templates/euid_details.html
+++ b/templates/euid_details.html
@@ -137,12 +137,15 @@
 
     <div class="collapsible-buttons">
         <button type="button" class="collapsiblex" data-target="relationshipsContent">Relationships</button>
+        {% if subjects_for_object %}
+        <button type="button" class="collapsiblex" data-target="subjectsContent">Subjects ({{ subjects_for_object|length }})</button>
+        {% endif %}
         <button style="display:none;" type="button" class="collapsiblex" data-target="dynamicFieldsContent">Dynamic Fields</button>
         <button type="button" class="collapsiblex" data-target="actionGroupsContent">Action Groups</button>
         <button type="button" class="collapsiblex" data-target="auditLogContent">Audit Log</button>
         <button type="button" class="collapsiblex" data-target="fullEditContent">Edit Obj Properties (admin)</button>
         {% if object.parent_template_euid %}
-            
+
         {% else %}
             <button type="button" class="collapsiblex" data-target="fullEditContentTemplate">Edit Template Form Properties (super admin)</button>
         {% endif %}
@@ -252,6 +255,41 @@
             {% endfor %}
         </table>
     </div>
+
+    {% if subjects_for_object %}
+    <div id="subjectsContent" class="content" style="display:none;">
+        <h2>Subjects (Decision Scopes)</h2>
+        <p><em>This object is part of the following subjects:</em></p>
+        <table class="searchable">
+            <tr>
+                <th>Subject EUID</th>
+                <th>Kind</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Subject Key</th>
+                <th>Name</th>
+            </tr>
+            {% for subject in subjects_for_object %}
+            <tr>
+                <td><a href="euid_details?euid={{ subject.euid }}">{{ subject.euid }}</a></td>
+                <td>{{ subject.kind }}</td>
+                <td>
+                    {% if subject.role == 'anchor' %}
+                        <span style="color: #007BFF; font-weight: bold;">⚓ Anchor</span>
+                    {% elif subject.role == 'member' %}
+                        <span style="color: #28a745;">📎 Member</span>
+                    {% else %}
+                        {{ subject.role }}
+                    {% endif %}
+                </td>
+                <td>{{ subject.status }}</td>
+                <td><code>{{ subject.subject_key }}</code></td>
+                <td>{{ subject.name }}</td>
+            </tr>
+            {% endfor %}
+        </table>
+    </div>
+    {% endif %}
 
     <div id="dynamicFieldsContent" class="content" style="display:none;">
         <div class="dynamic-fields">

--- a/tests/test_subject_model.py
+++ b/tests/test_subject_model.py
@@ -1,0 +1,160 @@
+"""
+Tests for the Subject model and subjecting module.
+
+Subjects are logical aggregates that decisions apply to, spanning multiple objects.
+This test module validates:
+- Subject creation and idempotency
+- Anchor and member relationships
+- Subject queries
+- Action integration
+"""
+
+import pytest
+from unittest.mock import Mock, MagicMock, patch
+import sys
+import os
+
+# Add the project root to the path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestSubjectKeyGeneration:
+    """Tests for subject key generation."""
+
+    def test_generate_subject_key_accession(self):
+        """Test subject key generation for accession type."""
+        from bloom_lims.subjecting import generate_subject_key
+        
+        key = generate_subject_key("accession", "CX123")
+        assert key == "accession:CX123"
+
+    def test_generate_subject_key_analysis_bundle(self):
+        """Test subject key generation for analysis_bundle type."""
+        from bloom_lims.subjecting import generate_subject_key
+        
+        key = generate_subject_key("analysis_bundle", "FX456")
+        assert key == "analysis_bundle:FX456"
+
+    def test_generate_subject_key_report(self):
+        """Test subject key generation for report type."""
+        from bloom_lims.subjecting import generate_subject_key
+        
+        key = generate_subject_key("report", "WX789")
+        assert key == "report:WX789"
+
+    def test_generate_subject_key_generic(self):
+        """Test subject key generation for generic type."""
+        from bloom_lims.subjecting import generate_subject_key
+        
+        key = generate_subject_key("generic", "EX100")
+        assert key == "generic:EX100"
+
+
+class TestSubjectTemplateMap:
+    """Tests for subject template mapping."""
+
+    def test_template_map_contains_expected_kinds(self):
+        """Test that template map contains all expected subject kinds."""
+        from bloom_lims.subjecting import SUBJECT_TEMPLATE_MAP
+        
+        expected_kinds = ["accession", "analysis_bundle", "report", "generic"]
+        for kind in expected_kinds:
+            assert kind in SUBJECT_TEMPLATE_MAP
+
+    def test_template_paths_are_valid_format(self):
+        """Test that template paths follow expected format."""
+        from bloom_lims.subjecting import SUBJECT_TEMPLATE_MAP
+        
+        for kind, path in SUBJECT_TEMPLATE_MAP.items():
+            parts = path.split("/")
+            assert len(parts) == 4, f"Template path for {kind} should have 4 parts"
+            assert parts[0] == "subject", f"Template path for {kind} should start with 'subject'"
+
+
+class TestRelationshipConstants:
+    """Tests for relationship type constants."""
+
+    def test_relationship_constants_defined(self):
+        """Test that relationship constants are properly defined."""
+        from bloom_lims.subjecting import (
+            RELATIONSHIP_SUBJECT_ANCHOR,
+            RELATIONSHIP_SUBJECT_MEMBER,
+        )
+        
+        assert RELATIONSHIP_SUBJECT_ANCHOR == "subject_anchor"
+        assert RELATIONSHIP_SUBJECT_MEMBER == "subject_member"
+
+
+class TestFindSubjectByKey:
+    """Tests for find_subject_by_key function."""
+
+    def test_find_subject_by_key_returns_none_when_not_found(self):
+        """Test that find_subject_by_key returns None when subject not found."""
+        from bloom_lims.subjecting import find_subject_by_key
+        
+        # Create mock bob with empty query results
+        mock_bob = Mock()
+        mock_bob.session.query.return_value.filter.return_value.all.return_value = []
+        
+        result = find_subject_by_key(mock_bob, "nonexistent:key")
+        assert result is None
+
+    def test_find_subject_by_key_returns_matching_subject(self):
+        """Test that find_subject_by_key returns matching subject."""
+        from bloom_lims.subjecting import find_subject_by_key
+        
+        # Create mock subject
+        mock_subject = Mock()
+        mock_subject.json_addl = {"properties": {"subject_key": "accession:CX123"}}
+        mock_subject.super_type = "subject"
+        mock_subject.is_deleted = False
+        
+        # Create mock bob
+        mock_bob = Mock()
+        mock_bob.session.query.return_value.filter.return_value.all.return_value = [mock_subject]
+        
+        result = find_subject_by_key(mock_bob, "accession:CX123")
+        assert result == mock_subject
+
+
+class TestListSubjectsForObject:
+    """Tests for list_subjects_for_object function."""
+
+    def test_list_subjects_for_object_returns_empty_when_no_subjects(self):
+        """Test that list_subjects_for_object returns empty list when no subjects."""
+        from bloom_lims.subjecting import list_subjects_for_object
+        
+        # Create mock object with no subject lineages
+        mock_obj = Mock()
+        mock_obj.child_of_lineages = []
+        
+        mock_bob = Mock()
+        mock_bob.get_by_euid.return_value = mock_obj
+        
+        result = list_subjects_for_object(mock_bob, "CX123")
+        assert result == []
+
+    def test_list_subjects_for_object_returns_none_when_object_not_found(self):
+        """Test that list_subjects_for_object returns empty list when object not found."""
+        from bloom_lims.subjecting import list_subjects_for_object
+        
+        mock_bob = Mock()
+        mock_bob.get_by_euid.return_value = None
+        
+        result = list_subjects_for_object(mock_bob, "NONEXISTENT")
+        assert result == []
+
+
+class TestListMembersForSubject:
+    """Tests for list_members_for_subject function."""
+
+    def test_list_members_for_subject_returns_empty_when_subject_not_found(self):
+        """Test that list_members_for_subject returns empty dict when subject not found."""
+        from bloom_lims.subjecting import list_members_for_subject
+        
+        mock_bob = Mock()
+        mock_bob.get_by_euid.return_value = None
+        
+        result = list_members_for_subject(mock_bob, "NONEXISTENT")
+        assert result == {"anchor": [], "members": []}
+


### PR DESCRIPTION
Add new Subject concept to separate facts (Objects) from decision scopes (Subjects).

Changes:
- Database: Add sx_instance_seq sequence and polymorphic ORM classes (subject_template, subject_instance, subject_instance_lineage)
- Config: Add subject templates for accession, analysis_bundle, report, and generic subject kinds
- Helper Functions: Create bloom_lims/subjecting.py with create_subject, add_subject_members, list_subjects_for_object, etc.
- Actions: Add create-subject-and-anchor action to core.json
- UI: Display subject relationships in euid_details.html
- Tests: Add test_subject_model.py with 12 passing tests
- Docs: Add Subjects vs Objects section to README.md

Subjects are logical aggregates that decisions apply to, spanning multiple objects. They have stable, deterministic keys and support idempotent creation.