### PR TITLE
fix: remap FI→FN and LM→EM prefixes for Meridian EUID compliance

### DIFF
--- a/bloom_lims/config/equipment/metadata.json
+++ b/bloom_lims/config/equipment/metadata.json
@@ -1,5 +1,5 @@
 {
   "euid_prefixes": {
-    "default": "LM"
+    "default": "EM"
   }
 }

--- a/bloom_lims/config/file/metadata.json
+++ b/bloom_lims/config/file/metadata.json
@@ -1,7 +1,7 @@
 {
   "euid_prefixes": {
     "default": "FG",
-    "file": "FI",
+    "file": "FN",
     "file_set": "FS",
     "shared_ref": "FX"
     }

--- a/bloom_lims/env/bloom_prefix_sequences.sql
+++ b/bloom_lims/env/bloom_prefix_sequences.sql
@@ -17,7 +17,7 @@ CREATE SEQUENCE IF NOT EXISTS mrx_instance_seq;  -- reagent
 CREATE SEQUENCE IF NOT EXISTS mcx_instance_seq;  -- control
 
 -- Equipment prefixes
-CREATE SEQUENCE IF NOT EXISTS lm_instance_seq;   -- default equipment (LM = Lab Machine/equipment)
+CREATE SEQUENCE IF NOT EXISTS em_instance_seq;   -- default equipment (EM = Equipment/Machine)
 CREATE SEQUENCE IF NOT EXISTS ex_instance_seq;   -- legacy equipment prefix (deprecated)
 
 -- Workflow prefixes
@@ -43,7 +43,7 @@ CREATE SEQUENCE IF NOT EXISTS xx_instance_seq;   -- default action
 
 -- File prefixes
 CREATE SEQUENCE IF NOT EXISTS fg_instance_seq;   -- default file (generic)
-CREATE SEQUENCE IF NOT EXISTS fi_instance_seq;   -- file
+CREATE SEQUENCE IF NOT EXISTS fn_instance_seq;   -- file (FN prefix)
 CREATE SEQUENCE IF NOT EXISTS fs_instance_seq;   -- file_set
 CREATE SEQUENCE IF NOT EXISTS fx_instance_seq;   -- shared_ref
 

--- a/bloom_lims/migrations/versions/20250203_0001_add_missing_euid_sequences.py
+++ b/bloom_lims/migrations/versions/20250203_0001_add_missing_euid_sequences.py
@@ -1,4 +1,4 @@
-"""Add missing EUID sequences for DAT, LM, HEV prefixes
+"""Add missing EUID sequences for DAT, EM, HEV prefixes
 
 This migration adds the missing PostgreSQL sequences required by the
 set_generic_instance_euid() trigger for template prefixes that were
@@ -6,7 +6,7 @@ added to metadata.json files but not to bloom_prefix_sequences.sql.
 
 Missing sequences:
 - dat_instance_seq: For data category templates (prefix DAT)
-- lm_instance_seq: For equipment category templates (prefix LM)
+- em_instance_seq: For equipment category templates (prefix EM, formerly LM)
 - hev_instance_seq: For health_event category templates (prefix HEV)
 
 The trigger dynamically constructs sequence names as {lowercase_prefix}_instance_seq
@@ -33,7 +33,7 @@ depends_on: Union[str, Sequence[str], None] = None
 # Format: (sequence_name, comment)
 MISSING_SEQUENCES = [
     ('dat_instance_seq', 'EUID sequence for data category templates (prefix DAT)'),
-    ('lm_instance_seq', 'EUID sequence for equipment category templates (prefix LM)'),
+    ('em_instance_seq', 'EUID sequence for equipment category templates (prefix EM)'),
     ('hev_instance_seq', 'EUID sequence for health_event category templates (prefix HEV)'),
 ]
 
@@ -61,11 +61,11 @@ def upgrade() -> None:
         SELECT sequence_name 
         FROM information_schema.sequences 
         WHERE sequence_schema = 'public'
-        AND sequence_name IN ('dat_instance_seq', 'lm_instance_seq', 'hev_instance_seq')
+        AND sequence_name IN ('dat_instance_seq', 'em_instance_seq', 'hev_instance_seq')
     """))
     
     created = [row[0] for row in result]
-    expected = {'dat_instance_seq', 'lm_instance_seq', 'hev_instance_seq'}
+    expected = {'dat_instance_seq', 'em_instance_seq', 'hev_instance_seq'}
     
     if set(created) != expected:
         missing = expected - set(created)

--- a/seed_db_containersGeneric.py
+++ b/seed_db_containersGeneric.py
@@ -17,7 +17,7 @@ def ensure_sequence_exists(db, prefix: str) -> None:
 
     Args:
         db: BLOOMdb3 database instance
-        prefix: The instance_prefix (e.g., 'DAT', 'LM', 'HEV')
+        prefix: The instance_prefix (e.g., 'DAT', 'EM', 'HEV')
     """
     seq_name = f"{prefix.lower()}_instance_seq"
 


### PR DESCRIPTION
Meridian SPEC.md §6.2 forbids characters I, L, O, U in EUIDs. Two prefixes violated this:
- FI (file) contains I → changed to FN
- LM (equipment) contains L → changed to EM

Files changed:
- bloom_lims/config/file/metadata.json: FI→FN
- bloom_lims/config/equipment/metadata.json: LM→EM
- bloom_lims/env/bloom_prefix_sequences.sql: fi_instance_seq→fn_instance_seq, lm_instance_seq→em_instance_seq
- bloom_lims/migrations/versions/20250203_0001_add_missing_euid_sequences.py: lm→em references
- seed_db_containersGeneric.py: docstring LM→EM