### PR TITLE
fix: correct GUI startup configuration for dev-v2 deployment

### DIFF
--- a/bloom_lims/cli/gui.py
+++ b/bloom_lims/cli/gui.py
@@ -119,7 +119,7 @@ def gui(port, host, reload, background):
         console.print("\n   Fix your config ([cyan]bloom config -e[/cyan]) or run [cyan]bloom db init[/cyan].")
         raise SystemExit(1)
 
-    pid = _get_pid()
+    pid = read_pid(PID_FILE)
     if pid:
         console.print(f"[yellow]⚠[/yellow]  Server already running (PID {pid})")
         console.print(f"   URL: [cyan]{protocol}://{display_host}:{port}[/cyan]")


### PR DESCRIPTION
## Summary

Fixes GUI startup configuration issue encountered during dev-v2 deployment.

### Files Changed
- `bloom_lims/cli/gui.py` — 1 line fix

## Verification

Deployed and verified on dev-v2 (`34.229.1.96`). Bloom GUI starts correctly on port 8912.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author