### PR TITLE
fix: use Cognito managed login logout flow with redirect_uri and response_type=code

### DIFF
--- a/auth/cognito/client.py
+++ b/auth/cognito/client.py
@@ -64,10 +64,13 @@ class CognitoConfig:
 
     @property
     def logout_url(self) -> str:
+        # Cognito managed login /logout requires redirect_uri (must match a
+        # registered CallbackURL) + response_type=code instead of logout_uri.
         query = urlencode(
             {
                 "client_id": self.client_id,
-                "logout_uri": self.logout_redirect_uri,
+                "redirect_uri": self.redirect_uri.rstrip("/"),
+                "response_type": "code",
             }
         )
         return f"https://{self._bare_domain}/logout?{query}"


### PR DESCRIPTION
## Summary

Fixes the logout → re-login flow for Cognito managed login.

### Changes

**`auth/cognito/client.py` — `CognitoConfig.logout_url`**
- Switch from `logout_uri` to `redirect_uri` + `response_type=code`
- `redirect_uri` must match a registered CallbackURL in Cognito managed login

### Testing
- Verified on sandbox `x` instance (`54.234.187.56`)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author