### PR TITLE
Release Bloom v0.11.13 with TapDB 3.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ Bloom template definitions are authored as JSON packs under
 `config/tapdb_templates/` and loaded through TapDB during `bloom db init` /
 `bloom db seed`.
 
+## Release Tags
+
+Bloom's historical Git release tags use the legacy `v*` format, for example
+`v0.11.12`. Downstream deployment tooling should pin the exact upstream tag
+that exists in the Bloom repo rather than stripping the `v`.
+
 ## API Surface
 
 Canonical prefix: `/api/v1`

--- a/bloom_lims/api/v1/dependencies.py
+++ b/bloom_lims/api/v1/dependencies.py
@@ -47,13 +47,13 @@ class APIUser:
         fallback_role = map_legacy_role(role)
         normalized_roles = normalize_roles(roles or ([fallback_role] if fallback_role else []), fallback=fallback_role)
         if not normalized_roles:
-            normalized_roles = [Role.INTERNAL_READ_WRITE.value]
+            normalized_roles = [Role.READ_WRITE.value]
         self.email = email
         self.user_id = user_id or email
         self.roles = normalized_roles
         self.groups = sorted(set(groups or []))
         self.permissions = sorted(set(permissions or effective_permissions(self.roles)))
-        self.role = role or self.roles[0]
+        self.role = self.roles[0]
         self.auth_source = auth_source
         self.is_service_account = is_service_account
         self.token_scope = token_scope
@@ -183,7 +183,7 @@ def _make_user(
     all_groups = sorted(set((groups_hint or []) + resolved_groups))
     if API_ACCESS_GROUP in all_groups and Permission.TOKEN_SELF_MANAGE.value not in permissions:
         permissions = sorted(set(permissions + [Permission.TOKEN_SELF_MANAGE.value]))
-    primary_role = roles[0] if roles else Role.INTERNAL_READ_WRITE.value
+    primary_role = roles[0] if roles else Role.READ_WRITE.value
     return APIUser(
         email=email,
         user_id=user_id or email,
@@ -220,7 +220,7 @@ def _authenticate_bloom_token(request: Request, token_value: str) -> APIUser:
             roles=constrained_roles,
             groups=owner_groups,
             permissions=permissions,
-            role=constrained_roles[0] if constrained_roles else Role.INTERNAL_READ_ONLY.value,
+            role=constrained_roles[0] if constrained_roles else Role.READ_ONLY.value,
             auth_source="token",
             is_service_account=True,
             token_scope=token_row.scope,
@@ -292,7 +292,7 @@ async def get_api_user(
         return _make_user(
             email=user_data.get("email", "session-user"),
             user_id=user_data.get("sub"),
-            role_hint=user_data.get("role") or user_data.get("custom:role"),
+            role_hint=user_data.get("role"),
             auth_source="session",
             groups_hint=user_data.get("groups") if isinstance(user_data.get("groups"), list) else [],
         )
@@ -315,7 +315,7 @@ async def get_api_user(
                 return _make_user(
                     email=claims.get("email", "token-user"),
                     user_id=claims.get("sub"),
-                    role_hint=claims.get("custom:role") or claims.get("role"),
+                    role_hint=None,
                     auth_source="cognito",
                     groups_hint=claims.get("cognito:groups")
                     if isinstance(claims.get("cognito:groups"), list)

--- a/bloom_lims/auth/__init__.py
+++ b/bloom_lims/auth/__init__.py
@@ -2,6 +2,12 @@
 
 from bloom_lims.auth.rbac import (
     API_ACCESS_GROUP,
+    BLOOM_ADMIN_GROUP,
+    BLOOM_AUDITOR_GROUP,
+    BLOOM_CLINICAL_GROUP,
+    BLOOM_READONLY_GROUP,
+    BLOOM_READWRITE_GROUP,
+    BLOOM_RND_GROUP,
     Permission,
     Role,
     can_write,
@@ -15,6 +21,12 @@ from bloom_lims.auth.rbac import (
 
 __all__ = [
     "API_ACCESS_GROUP",
+    "BLOOM_ADMIN_GROUP",
+    "BLOOM_AUDITOR_GROUP",
+    "BLOOM_CLINICAL_GROUP",
+    "BLOOM_READONLY_GROUP",
+    "BLOOM_READWRITE_GROUP",
+    "BLOOM_RND_GROUP",
     "Permission",
     "Role",
     "can_write",
@@ -25,4 +37,3 @@ __all__ = [
     "is_admin",
     "normalize_roles",
 ]
-

--- a/bloom_lims/auth/rbac.py
+++ b/bloom_lims/auth/rbac.py
@@ -9,8 +9,8 @@ from enum import StrEnum
 class Role(StrEnum):
     """Supported Bloom roles."""
 
-    INTERNAL_READ_ONLY = "INTERNAL_READ_ONLY"
-    INTERNAL_READ_WRITE = "INTERNAL_READ_WRITE"
+    READ_ONLY = "READ_ONLY"
+    READ_WRITE = "READ_WRITE"
     ADMIN = "ADMIN"
 
 
@@ -27,13 +27,19 @@ class Permission(StrEnum):
 API_ACCESS_GROUP = "API_ACCESS"
 ENABLE_ATLAS_API_GROUP = "ENABLE_ATLAS_API"
 ENABLE_URSA_API_GROUP = "ENABLE_URSA_API"
+BLOOM_READONLY_GROUP = "bloom-readonly"
+BLOOM_READWRITE_GROUP = "bloom-readwrite"
+BLOOM_ADMIN_GROUP = "bloom-admin"
+BLOOM_RND_GROUP = "bloom-rnd"
+BLOOM_CLINICAL_GROUP = "bloom-clinical"
+BLOOM_AUDITOR_GROUP = "bloom-auditor"
 
 ROLE_PERMISSIONS: dict[Role, set[Permission]] = {
-    Role.INTERNAL_READ_ONLY: {
+    Role.READ_ONLY: {
         Permission.BLOOM_READ,
         Permission.TOKEN_SELF_MANAGE,
     },
-    Role.INTERNAL_READ_WRITE: {
+    Role.READ_WRITE: {
         Permission.BLOOM_READ,
         Permission.BLOOM_WRITE,
         Permission.TOKEN_SELF_MANAGE,
@@ -42,18 +48,18 @@ ROLE_PERMISSIONS: dict[Role, set[Permission]] = {
 }
 
 ROLE_RANK: dict[Role, int] = {
-    Role.INTERNAL_READ_ONLY: 1,
-    Role.INTERNAL_READ_WRITE: 2,
+    Role.READ_ONLY: 1,
+    Role.READ_WRITE: 2,
     Role.ADMIN: 3,
 }
 
 SCOPE_ROLE_CAP: dict[str, Role] = {
-    "internal_ro": Role.INTERNAL_READ_ONLY,
-    "internal_rw": Role.INTERNAL_READ_WRITE,
+    "internal_ro": Role.READ_ONLY,
+    "internal_rw": Role.READ_WRITE,
     "admin": Role.ADMIN,
 }
 
-DEFAULT_ROLE = Role.INTERNAL_READ_WRITE
+DEFAULT_ROLE = Role.READ_WRITE
 
 
 def _normalize_role(role_value: str | Role | None) -> Role | None:
@@ -67,16 +73,7 @@ def _normalize_role(role_value: str | Role | None) -> Role | None:
     for role in Role:
         if candidate == role.value:
             return role
-    # Backward compatibility aliases used by existing Bloom auth.
-    alias_map = {
-        "user": Role.INTERNAL_READ_WRITE,
-        "service": Role.ADMIN,
-        "admin": Role.ADMIN,
-        "read_only": Role.INTERNAL_READ_ONLY,
-        "read-write": Role.INTERNAL_READ_WRITE,
-        "read_write": Role.INTERNAL_READ_WRITE,
-    }
-    return alias_map.get(candidate.lower())
+    return None
 
 
 def normalize_roles(

--- a/bloom_lims/auth/services/groups.py
+++ b/bloom_lims/auth/services/groups.py
@@ -8,6 +8,12 @@ from sqlalchemy.orm import Session
 
 from bloom_lims.auth.rbac import (
     API_ACCESS_GROUP,
+    BLOOM_ADMIN_GROUP,
+    BLOOM_AUDITOR_GROUP,
+    BLOOM_CLINICAL_GROUP,
+    BLOOM_READONLY_GROUP,
+    BLOOM_READWRITE_GROUP,
+    BLOOM_RND_GROUP,
     ENABLE_ATLAS_API_GROUP,
     ENABLE_URSA_API_GROUP,
     Role,
@@ -17,33 +23,29 @@ from bloom_lims.auth.repositories.tapdb.groups import GroupMembershipRecord, Gro
 
 
 SYSTEM_GROUP_CODES = [
-    Role.INTERNAL_READ_ONLY.value,
-    Role.INTERNAL_READ_WRITE.value,
-    Role.ADMIN.value,
+    BLOOM_READONLY_GROUP,
+    BLOOM_READWRITE_GROUP,
+    BLOOM_ADMIN_GROUP,
+    BLOOM_RND_GROUP,
+    BLOOM_CLINICAL_GROUP,
+    BLOOM_AUDITOR_GROUP,
     API_ACCESS_GROUP,
     ENABLE_ATLAS_API_GROUP,
     ENABLE_URSA_API_GROUP,
 ]
 
-LEGACY_ROLE_TO_BLOOM_ROLE = {
-    "admin": Role.ADMIN.value,
-    "service": Role.ADMIN.value,
-    "user": Role.INTERNAL_READ_WRITE.value,
-    "read_only": Role.INTERNAL_READ_ONLY.value,
-    "read-write": Role.INTERNAL_READ_WRITE.value,
-    "read_write": Role.INTERNAL_READ_WRITE.value,
+GROUP_ROLE_MAP = {
+    BLOOM_READONLY_GROUP: Role.READ_ONLY.value,
+    BLOOM_READWRITE_GROUP: Role.READ_WRITE.value,
+    BLOOM_ADMIN_GROUP: Role.ADMIN.value,
 }
 
 
 def map_legacy_role(role_value: str | None) -> str:
-    if role_value is None:
-        return Role.INTERNAL_READ_WRITE.value
-    candidate = str(role_value).strip()
-    if not candidate:
-        return Role.INTERNAL_READ_WRITE.value
+    candidate = str(role_value or "").strip()
     if candidate in {role.value for role in Role}:
         return candidate
-    return LEGACY_ROLE_TO_BLOOM_ROLE.get(candidate.lower(), Role.INTERNAL_READ_WRITE.value)
+    return Role.READ_WRITE.value
 
 
 @dataclass(frozen=True)
@@ -104,6 +106,6 @@ class GroupService:
     ) -> GroupResolution:
         fallback = map_legacy_role(fallback_role)
         groups = self.get_group_codes_for_user(user_id)
-        role_groups = [group for group in groups if group in {role.value for role in Role}]
+        role_groups = [GROUP_ROLE_MAP[group] for group in groups if group in GROUP_ROLE_MAP]
         roles = normalize_roles(role_groups or [fallback], fallback=fallback)
         return GroupResolution(roles=roles, groups=sorted(groups))

--- a/bloom_lims/auth/services/user_api_tokens.py
+++ b/bloom_lims/auth/services/user_api_tokens.py
@@ -78,12 +78,12 @@ class UserAPITokenService:
 
     @staticmethod
     def allowed_scopes_for_roles(actor_roles: list[str]) -> set[str]:
-        roles = normalize_roles(actor_roles, fallback=Role.INTERNAL_READ_WRITE.value)
+        roles = normalize_roles(actor_roles, fallback=Role.READ_WRITE.value)
         if is_admin(roles):
             return {"internal_ro", "internal_rw", "admin"}
-        if Role.INTERNAL_READ_WRITE.value in roles:
+        if Role.READ_WRITE.value in roles:
             return {"internal_ro", "internal_rw"}
-        if Role.INTERNAL_READ_ONLY.value in roles:
+        if Role.READ_ONLY.value in roles:
             return {"internal_ro"}
         return set()
 
@@ -97,7 +97,7 @@ class UserAPITokenService:
         payload: TokenCreateInput,
     ) -> TokenCreateResult:
         self.groups.ensure_system_groups()
-        normalized_roles = normalize_roles(actor_roles, fallback=Role.INTERNAL_READ_WRITE.value)
+        normalized_roles = normalize_roles(actor_roles, fallback=Role.READ_WRITE.value)
         group_set = {group.upper() for group in actor_groups}
         actor_is_admin = is_admin(normalized_roles)
         if not actor_is_admin and API_ACCESS_GROUP not in group_set:
@@ -158,7 +158,7 @@ class UserAPITokenService:
         if current is None:
             return None
         token, revision = current
-        roles = normalize_roles(actor_roles, fallback=Role.INTERNAL_READ_WRITE.value)
+        roles = normalize_roles(actor_roles, fallback=Role.READ_WRITE.value)
         if token.user_id != actor_user_id and not is_admin(roles):
             raise PermissionError("Cannot revoke another user's token")
 
@@ -269,7 +269,7 @@ class UserAPITokenService:
         if token_result is None:
             return []
         token, _ = token_result
-        roles = normalize_roles(actor_roles, fallback=Role.INTERNAL_READ_WRITE.value)
+        roles = normalize_roles(actor_roles, fallback=Role.READ_WRITE.value)
         if token.user_id != actor_user_id and not is_admin(roles):
             raise PermissionError("Cannot view usage for another user's token")
         return self.repo.get_usage_logs(token_id=token_id, limit=max(1, min(limit, 1000)))
@@ -281,6 +281,6 @@ class UserAPITokenService:
     ) -> tuple[list[str], list[str]]:
         owner = self.groups.resolve_user_roles_and_groups(
             user_id=token.user_id,
-            fallback_role=Role.INTERNAL_READ_ONLY.value,
+            fallback_role=Role.READ_ONLY.value,
         )
         return constrain_roles_by_scope(owner.roles, token.scope), owner.groups

--- a/bloom_lims/gui/deps.py
+++ b/bloom_lims/gui/deps.py
@@ -180,7 +180,8 @@ async def require_auth(request: Request):
         request.session["user_data"] = {
             "email": "john@daylilyinformatics.bio",
             "dag_fnv2": "",
-            "role": "admin",
+            "role": "ADMIN",
+            "roles": ["ADMIN"],
             "display_timezone": DEFAULT_DISPLAY_TIMEZONE,
         }
         return request
@@ -199,7 +200,7 @@ async def require_auth(request: Request):
         raise AuthenticationRequiredException()
 
     if "role" not in request.session["user_data"]:
-        request.session["user_data"]["role"] = "user"
+        request.session["user_data"]["role"] = "READ_WRITE"
 
     return request.session["user_data"]
 
@@ -212,13 +213,13 @@ def _resolve_auth_email(auth: Dict, request: Request) -> str:
 
 def _resolve_auth_role(auth: Dict, request: Request) -> str:
     if isinstance(auth, dict) and auth.get("role"):
-        return str(auth["role"])
-    return str(request.session.get("user_data", {}).get("role", "user"))
+        return str(auth["role"]).strip().upper()
+    return str(request.session.get("user_data", {}).get("role", "READ_WRITE")).strip().upper()
 
 
 def _require_graph_admin(auth: Dict, request: Request) -> None:
     role = _resolve_auth_role(auth, request)
-    if role != "admin":
+    if role != "ADMIN":
         raise HTTPException(status_code=403, detail="Admin role required")
 
 

--- a/bloom_lims/gui/routes/auth.py
+++ b/bloom_lims/gui/routes/auth.py
@@ -9,7 +9,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from auth.cognito.client import CognitoConfigurationError, CognitoTokenError
 from bloom_lims.auth.rbac import Role
-from bloom_lims.auth.services.groups import GroupService, map_legacy_role
+from bloom_lims.auth.services.groups import GroupService
 from bloom_lims.db import BLOOMdb3
 from bloom_lims.gui.deps import _get_request_cognito_auth, get_allowed_domains, get_user_preferences, require_auth
 from bloom_lims.gui.errors import MissingCognitoEnvVarsException
@@ -82,7 +82,7 @@ def _resolve_login_roles_and_groups(
         return resolution.roles, resolution.groups, default_user_id
     except Exception as exc:
         logging.warning("Failed to resolve session RBAC for %s: %s", normalized_email, exc)
-        return [fallback or Role.INTERNAL_READ_WRITE.value], [], (normalized_sub or normalized_email)
+        return [fallback or Role.READ_WRITE.value], [], (normalized_sub or normalized_email)
     finally:
         bdb.close()
 
@@ -134,14 +134,13 @@ async def _complete_cognito_login(
                 detail="Email domain not allowed",
             )
 
-    token_role_hint = decoded_token.get("custom:role") or decoded_token.get("role")
     cognito_sub = decoded_token.get("sub")
     roles, groups, resolved_user_id = _resolve_login_roles_and_groups(
         email=primary_email,
         cognito_sub=cognito_sub,
-        fallback_role=token_role_hint,
+        fallback_role=None,
     )
-    primary_role = (roles[0] if roles else map_legacy_role(token_role_hint)).upper()
+    primary_role = (roles[0] if roles else Role.READ_WRITE.value).upper()
 
     user_data = get_user_preferences(primary_email)
     user_data.update(

--- a/bloom_lims/gui/routes/graph.py
+++ b/bloom_lims/gui/routes/graph.py
@@ -105,7 +105,7 @@ async def dindex2(
         "start_euid": resolved_start_euid,
         "depth": resolved_depth,
         "merge_ref": merge_ref,
-        "is_admin": user_role == "admin",
+        "is_admin": user_role == "ADMIN",
         "udat": user_data,
     }
     return HTMLResponse(content=template.render(**context))

--- a/bloom_lims/gui/routes/operations.py
+++ b/bloom_lims/gui/routes/operations.py
@@ -66,11 +66,11 @@ class FormField(BaseModel):
 
 def _session_role(request: Request) -> str:
     user_data = request.session.get("user_data", {})
-    return str(user_data.get("role", "user")).strip().lower()
+    return str(user_data.get("role", "READ_WRITE")).strip().upper()
 
 
 def _is_admin_session(request: Request) -> bool:
-    return _session_role(request) == "admin"
+    return _session_role(request) == "ADMIN"
 
 
 def _admin_forbidden_response(request: Request):
@@ -991,7 +991,7 @@ async def euid_details(
 
         subjects_for_object = list_subjects_for_object(bobdb, euid)
 
-        is_admin = user_data.get("role", "user") == "admin"
+        is_admin = str(user_data.get("role", "READ_WRITE")).strip().upper() == "ADMIN"
         action_groups = {}
         if isinstance(obj.json_addl, dict):
             action_groups = _hydrate_dynamic_action_groups(

--- a/bloom_lims/integrations/tapdb_mount.py
+++ b/bloom_lims/integrations/tapdb_mount.py
@@ -73,13 +73,13 @@ def _resolve_bloom_user_data(scope: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def _is_admin_user(user_data: dict[str, Any]) -> bool:
-    role = str(user_data.get("role") or "").strip().lower()
-    if role == "admin":
+    role = str(user_data.get("role") or "").strip().upper()
+    if role == "ADMIN":
         return True
     roles = user_data.get("roles")
     if not isinstance(roles, list):
         return False
-    return any(str(item).strip().lower() == "admin" for item in roles)
+    return any(str(item).strip().upper() == "ADMIN" for item in roles)
 
 
 class BloomAdminGuardedASGI:
@@ -155,4 +155,3 @@ def mount_tapdb_admin_subapp(app: FastAPI) -> TapDBMountConfig | None:
     app.mount(config.mount_path, BloomAdminGuardedASGI(tapdb_admin_app), name="tapdb_admin")
     logger.info("Mounted TapDB admin app at %s", config.mount_path)
     return config
-

--- a/docs/AUTH_INTEGRATION.md
+++ b/docs/AUTH_INTEGRATION.md
@@ -5,8 +5,8 @@ This document describes Bloom's token-first external API model and Atlas integra
 ## RBAC Model
 
 Bloom roles:
-- `INTERNAL_READ_ONLY`
-- `INTERNAL_READ_WRITE`
+- `READ_ONLY`
+- `READ_WRITE`
 - `ADMIN`
 
 Bloom permissions:
@@ -17,10 +17,15 @@ Bloom permissions:
 - `token:admin_manage`
 
 System groups:
-- `INTERNAL_READ_ONLY`
-- `INTERNAL_READ_WRITE`
-- `ADMIN`
+- `bloom-readonly`
+- `bloom-readwrite`
+- `bloom-admin`
+- `bloom-rnd`
+- `bloom-clinical`
+- `bloom-auditor`
 - `API_ACCESS`
+- `ENABLE_ATLAS_API`
+- `ENABLE_URSA_API`
 
 `API_ACCESS` gates personal API token self-service. Admin users can always manage tokens.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory mixes current reference docs with historical planning material.
 - [bloom_beta_api_contracts.md](bloom_beta_api_contracts.md): current Bloom beta integration contract
 - [SEARCH_V2.md](SEARCH_V2.md): unified search API and GUI notes
 - [AUTHENTICATION.md](AUTHENTICATION.md): auth behavior and Cognito details
+- [RELEASE_TAG_POLICY.md](RELEASE_TAG_POLICY.md): release tag format and legacy `v*` tag note
 
 ## Historical / Planning Docs
 

--- a/docs/RELEASE_TAG_POLICY.md
+++ b/docs/RELEASE_TAG_POLICY.md
@@ -1,0 +1,19 @@
+# Bloom Release Tag Policy
+
+Bloom's historical Git release tags use the legacy `v*` form, for example
+`v0.11.12`.
+
+This is a repository history convention, not a semantic difference in the
+release itself. Downstream tooling that deploys or pins Bloom should use the
+exact upstream tag that exists in the Bloom repo.
+
+Current policy:
+
+- Existing `v*` tags are legacy-format release tags and remain valid.
+- Do not invent normalized bare-semver aliases in downstream deploy manifests
+  unless those tags actually exist upstream.
+- Deployment tooling should accept the exact upstream release tag format.
+
+If Bloom adopts bare semver tags in a later release wave, that policy change
+should be documented here and reflected in downstream pinning rules at the
+same time.

--- a/docs/TAPDB_CLI_SPECIFICATION.md
+++ b/docs/TAPDB_CLI_SPECIFICATION.md
@@ -118,10 +118,15 @@ Bloom auth group/token metadata is persisted in TapDB generic templates:
 - `bloom/auth/user-api-token-usage-log/1.0/`
 
 System groups are automatically bootstrapped on demand:
-- `INTERNAL_READ_ONLY`
-- `INTERNAL_READ_WRITE`
-- `ADMIN`
+- `bloom-readonly`
+- `bloom-readwrite`
+- `bloom-admin`
+- `bloom-rnd`
+- `bloom-clinical`
+- `bloom-auditor`
 - `API_ACCESS`
+- `ENABLE_ATLAS_API`
+- `ENABLE_URSA_API`
 
 To test legacy API key behavior in local development only:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ license = {text = "MIT"}
 requires-python = ">=3.12"
 dependencies = [
     "cli-core-yo>=0.2.1",
-    "daylily-tapdb==3.0.7",
+    "daylily-tapdb==3.0.9",
     "daylily-cognito==0.1.30",
     "fastapi>=0.110.0",
     "httpx>=0.27.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ zebra_day==2.4.4
 fedex_tracking_day==0.2.8
 setuptools~=51.1.0
 SQLAlchemy~=2.0.19
-daylily-tapdb==3.0.7
+daylily-tapdb==3.0.9
 daylily-cognito==0.1.30
 pytz~=2023.3
 h11~=0.14.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,7 +241,7 @@ def mock_api_auth():
     mock_user = APIUser(
         user_id="test-user-id",
         email="test@example.com",
-        role="admin",
+        role="ADMIN",
     )
 
     with patch(

--- a/tests/test_api_atlas_bridge.py
+++ b/tests/test_api_atlas_bridge.py
@@ -34,7 +34,7 @@ def _external_rw_user() -> APIUser:
     return APIUser(
         email="atlas-bridge@example.com",
         user_id=_opaque_id("user"),
-        roles=["INTERNAL_READ_WRITE"],
+        roles=["READ_WRITE"],
         groups=[API_ACCESS_GROUP, ENABLE_ATLAS_API_GROUP],
         auth_source="token",
         is_service_account=True,
@@ -47,7 +47,7 @@ def _external_ro_user() -> APIUser:
     return APIUser(
         email="atlas-bridge-ro@example.com",
         user_id=_opaque_id("user"),
-        roles=["INTERNAL_READ_ONLY"],
+        roles=["READ_ONLY"],
         groups=[API_ACCESS_GROUP, ENABLE_ATLAS_API_GROUP],
         auth_source="token",
         is_service_account=True,

--- a/tests/test_api_auth_rbac.py
+++ b/tests/test_api_auth_rbac.py
@@ -44,7 +44,7 @@ def test_require_write_blocks_read_only_user():
     user = APIUser(
         email="ro@example.com",
         user_id="ro-user-1",
-        roles=["INTERNAL_READ_ONLY"],
+        roles=["READ_ONLY"],
     )
     with pytest.raises(HTTPException) as exc:
         asyncio.run(require_write(user))
@@ -56,7 +56,7 @@ def test_require_external_token_auth_blocks_non_token_user():
     user = APIUser(
         email="session@example.com",
         user_id="session-user-1",
-        roles=["INTERNAL_READ_WRITE"],
+        roles=["READ_WRITE"],
         auth_source="session",
     )
     with pytest.raises(HTTPException) as exc:

--- a/tests/test_atlas_workflow_contract.py
+++ b/tests/test_atlas_workflow_contract.py
@@ -85,7 +85,7 @@ def _token_user() -> APIUser:
     return APIUser(
         email="atlas-contract@example.com",
         user_id=_opaque("user"),
-        roles=["INTERNAL_READ_WRITE"],
+        roles=["READ_WRITE"],
         auth_source="token",
         is_service_account=True,
         token_scope="internal_rw",

--- a/tests/test_beta_cross_repo_smoke.py
+++ b/tests/test_beta_cross_repo_smoke.py
@@ -120,7 +120,7 @@ def _external_rw_user() -> APIUser:
     return APIUser(
         email="beta-smoke@example.com",
         user_id=f"user-{token}",
-        roles=["INTERNAL_READ_WRITE"],
+        roles=["READ_WRITE"],
         groups=[ENABLE_ATLAS_API_GROUP, ENABLE_URSA_API_GROUP],
         auth_source="token",
         is_service_account=True,

--- a/tests/test_beta_lab.py
+++ b/tests/test_beta_lab.py
@@ -30,7 +30,7 @@ def _token_user(groups: list[str]) -> APIUser:
     return APIUser(
         email="token-user@example.com",
         user_id="token-user",
-        roles=["INTERNAL_READ_ONLY"],
+        roles=["READ_ONLY"],
         groups=groups,
         auth_source="token",
     )
@@ -54,7 +54,7 @@ def test_run_resolver_requires_full_key_query_params():
     app.dependency_overrides[require_external_ursa_read] = lambda: APIUser(
         email="resolver-user@example.com",
         user_id="resolver-user",
-        roles=["INTERNAL_READ_ONLY"],
+        roles=["READ_ONLY"],
         groups=[ENABLE_URSA_API_GROUP],
         auth_source="token",
     )
@@ -73,7 +73,7 @@ def test_material_registration_links_fulfillment_items_on_container_and_patient_
         return APIUser(
             email="atlas-beta@example.com",
             user_id=f"atlas-user-{token}",
-            roles=["INTERNAL_READ_WRITE"],
+            roles=["READ_WRITE"],
             groups=[ENABLE_ATLAS_API_GROUP],
             auth_source="token",
             is_service_account=True,
@@ -220,7 +220,7 @@ def test_empty_tube_create_and_specimen_update_use_collection_event_reference(bd
         return APIUser(
             email="atlas-beta@example.com",
             user_id=f"atlas-user-{token}",
-            roles=["INTERNAL_READ_WRITE"],
+            roles=["READ_WRITE"],
             groups=[ENABLE_ATLAS_API_GROUP],
             auth_source="token",
             is_service_account=True,

--- a/tests/test_beta_modern_action_system.py
+++ b/tests/test_beta_modern_action_system.py
@@ -42,7 +42,7 @@ def _external_rw_user() -> APIUser:
     return APIUser(
         email="beta-modern-actions@example.com",
         user_id=f"user-{token}",
-        roles=["INTERNAL_READ_WRITE"],
+        roles=["READ_WRITE"],
         groups=[ENABLE_ATLAS_API_GROUP, ENABLE_URSA_API_GROUP],
         auth_source="token",
         is_service_account=True,

--- a/tests/test_execution_queue_api.py
+++ b/tests/test_execution_queue_api.py
@@ -30,7 +30,7 @@ def _internal_rw_user() -> APIUser:
     return APIUser(
         email="execution-api@example.com",
         user_id=_opaque("user"),
-        roles=["INTERNAL_READ_WRITE"],
+        roles=["READ_WRITE"],
         auth_source="token",
         token_scope="internal_rw",
         token_id=_opaque("token"),
@@ -41,7 +41,7 @@ def _internal_ro_user() -> APIUser:
     return APIUser(
         email="execution-api-ro@example.com",
         user_id=_opaque("user"),
-        roles=["INTERNAL_READ_ONLY"],
+        roles=["READ_ONLY"],
         auth_source="token",
         token_scope="internal_ro",
         token_id=_opaque("token"),

--- a/tests/test_external_specimens.py
+++ b/tests/test_external_specimens.py
@@ -15,7 +15,7 @@ def _token_user(groups: list[str]) -> APIUser:
     return APIUser(
         email="token-user@example.com",
         user_id="token-user",
-        roles=["INTERNAL_READ_WRITE"],
+        roles=["READ_WRITE"],
         groups=groups,
         auth_source="token",
     )

--- a/tests/test_graph_viewer_api.py
+++ b/tests/test_graph_viewer_api.py
@@ -366,7 +366,7 @@ class TestGraphViewerApis:
 
     def test_api_lineage_rejects_non_admin(self, client):
         def _non_admin_auth():
-            return {"email": "john@daylilyinformatics.bio", "role": "user"}
+            return {"email": "john@daylilyinformatics.bio", "role": "READ_WRITE"}
 
         app.dependency_overrides[require_auth] = _non_admin_auth
         try:
@@ -433,7 +433,7 @@ class TestGraphViewerApis:
 
     def test_api_object_delete_rejects_non_admin(self, client):
         def _non_admin_auth():
-            return {"email": "john@daylilyinformatics.bio", "role": "user"}
+            return {"email": "john@daylilyinformatics.bio", "role": "READ_WRITE"}
 
         app.dependency_overrides[require_auth] = _non_admin_auth
         try:

--- a/tests/test_gui_endpoints.py
+++ b/tests/test_gui_endpoints.py
@@ -926,7 +926,7 @@ class TestModernUINavigation:
         async def _non_admin_auth(request: Request):
             request.session["user_data"] = {
                 "email": "non-admin@example.com",
-                "role": "user",
+                "role": "READ_WRITE",
                 "dag_fnv2": "",
             }
             return request.session["user_data"]

--- a/tests/test_queue_flow.py
+++ b/tests/test_queue_flow.py
@@ -34,7 +34,7 @@ def _external_rw_user() -> APIUser:
     return APIUser(
         email="beta-queue@example.com",
         user_id=f"user-{token}",
-        roles=["INTERNAL_READ_WRITE"],
+        roles=["READ_WRITE"],
         groups=[ENABLE_ATLAS_API_GROUP, ENABLE_URSA_API_GROUP],
         auth_source="token",
         is_service_account=True,

--- a/tests/test_run_resolver.py
+++ b/tests/test_run_resolver.py
@@ -28,7 +28,7 @@ def _external_rw_user() -> APIUser:
     return APIUser(
         email="beta-resolver@example.com",
         user_id=f"user-{token}",
-        roles=["INTERNAL_READ_WRITE"],
+        roles=["READ_WRITE"],
         groups=[ENABLE_ATLAS_API_GROUP, ENABLE_URSA_API_GROUP],
         auth_source="token",
         is_service_account=True,

--- a/tests/test_tapdb_mount.py
+++ b/tests/test_tapdb_mount.py
@@ -41,7 +41,7 @@ def test_non_admin_authenticated_user_is_denied(monkeypatch):
     monkeypatch.setattr(
         tapdb_mount,
         "_resolve_bloom_user_data",
-        lambda _scope: {"email": "user@example.com", "role": "user"},
+        lambda _scope: {"email": "user@example.com", "role": "READ_WRITE"},
     )
     with _client() as client:
         response = client.get("/admin/tapdb/login", follow_redirects=False)
@@ -61,7 +61,7 @@ def test_admin_user_can_access_mounted_surface(monkeypatch):
     monkeypatch.setattr(
         tapdb_mount,
         "_resolve_bloom_user_data",
-        lambda _scope: {"email": "admin@example.com", "role": "admin"},
+        lambda _scope: {"email": "admin@example.com", "role": "ADMIN"},
     )
     with _client() as client:
         response = client.get("/admin/tapdb/login", follow_redirects=False)
@@ -73,7 +73,7 @@ def test_tapdb_local_auth_not_required_in_mounted_mode(monkeypatch):
     monkeypatch.setattr(
         tapdb_mount,
         "_resolve_bloom_user_data",
-        lambda _scope: {"email": "admin@example.com", "role": "admin"},
+        lambda _scope: {"email": "admin@example.com", "role": "ADMIN"},
     )
     with _client() as client:
         response = client.get("/admin/tapdb/login", follow_redirects=False)
@@ -85,7 +85,7 @@ def test_bloom_single_app_serves_api_and_tapdb_mount(monkeypatch):
     monkeypatch.setattr(
         tapdb_mount,
         "_resolve_bloom_user_data",
-        lambda _scope: {"email": "admin@example.com", "role": "admin"},
+        lambda _scope: {"email": "admin@example.com", "role": "ADMIN"},
     )
     with _client() as client:
         api_response = client.get("/api/v1/")


### PR DESCRIPTION
## Summary
- bump Bloom's daylily-tapdb pin from 3.0.7 to 3.0.9
- include the current Bloom auth, TapDB mount, docs, and test worktree changes
- document Bloom's legacy v-prefixed tag policy

## Validation
- source ./activate && pytest -q --no-cov tests/test_api_auth_rbac.py tests/test_gui_endpoints.py tests/test_tapdb_mount.py tests/test_api_atlas_bridge.py
- source ./activate && pytest -q tests/test_api_auth_rbac.py tests/test_gui_endpoints.py tests/test_tapdb_mount.py tests/test_api_atlas_bridge.py  # behavioral pass, coverage gate expected on narrow slice