### PR TITLE
Add Bloom anomaly registry surfaces

### DIFF
--- a/bloom_lims/anomalies.py
+++ b/bloom_lims/anomalies.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from daylily_tapdb import require_seeded_templates
+from daylily_tapdb.factory import InstanceFactory
+from daylily_tapdb.models.instance import generic_instance
+from daylily_tapdb.templates import TemplateManager
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from bloom_lims.config import get_settings
+from bloom_lims.observability import ProjectionMetadata
+
+ANOMALY_TEMPLATE_CODE = "bloom/ops/anomaly-record/1.0/"
+ANOMALY_PREFIX = "BAN"
+
+
+@dataclass(frozen=True)
+class AnomalyRecord:
+    id: str
+    service: str
+    environment: str
+    category: str
+    severity: str
+    fingerprint: str
+    summary: str
+    first_seen_at: str
+    last_seen_at: str
+    occurrence_count: int
+    redacted_context: dict[str, Any]
+    source_view_url: str
+
+
+def redact_context(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            lowered = str(key).lower()
+            if lowered in {"authorization", "cookie", "set-cookie", "token", "secret", "password"}:
+                redacted[str(key)] = "[redacted]"
+            else:
+                redacted[str(key)] = redact_context(item)
+        return redacted
+    if isinstance(value, list):
+        return [redact_context(item) for item in value]
+    if isinstance(value, str):
+        text = value
+        for prefix in ("/documents/", "/patients/", "/subjects/"):
+            if prefix in text:
+                head, _, tail = text.partition(prefix)
+                parts = tail.split("/", 1)
+                if parts and parts[0].isdigit():
+                    suffix = f"/{parts[1]}" if len(parts) > 1 else ""
+                    text = f"{head}{prefix}{{id}}{suffix}"
+        if "select " in text.lower():
+            return "[redacted-sql]"
+        return text
+    return value
+
+
+class TapdbAnomalyRepository:
+    def __init__(self, db: Session):
+        self.db = db
+        self.templates = TemplateManager()
+        self.factory = InstanceFactory(self.templates)
+        self._templates_ready = False
+
+    def projection(self, *, observed_at: str | None = None) -> ProjectionMetadata:
+        seen_at = observed_at or datetime.now(UTC).isoformat()
+        return ProjectionMetadata(
+            state="ready",
+            stale=False,
+            observed_at=seen_at,
+            last_synced_at=seen_at,
+            detail=None,
+        )
+
+    def record(
+        self,
+        *,
+        category: str,
+        severity: str,
+        fingerprint: str,
+        summary: str,
+        redacted_context: dict[str, Any] | None = None,
+    ) -> AnomalyRecord:
+        self._ensure_templates()
+        now = datetime.now(UTC).isoformat()
+        environment = get_settings().environment or "unknown"
+        context = redact_context(redacted_context or {})
+        existing = self._find_existing(
+            category=category,
+            severity=severity,
+            fingerprint=fingerprint,
+            environment=environment,
+        )
+        if existing is None:
+            instance = self.factory.create_instance(
+                session=self.db,
+                template_code=ANOMALY_TEMPLATE_CODE,
+                name=summary[:120],
+                properties={
+                    "service": "bloom",
+                    "environment": environment,
+                    "category": category,
+                    "severity": severity,
+                    "fingerprint": fingerprint,
+                    "summary": summary,
+                    "first_seen_at": now,
+                    "last_seen_at": now,
+                    "occurrence_count": 1,
+                    "redacted_context": context,
+                },
+            )
+        else:
+            props = self._props(existing)
+            props["summary"] = summary
+            props["last_seen_at"] = now
+            props["occurrence_count"] = int(props.get("occurrence_count") or 0) + 1
+            props["redacted_context"] = context
+            self._write_props(existing, props)
+            instance = existing
+        self.db.commit()
+        return self._to_record(instance)
+
+    def list(self, *, skip: int = 0, limit: int = 100) -> list[AnomalyRecord]:
+        self._ensure_templates()
+        rows = [self._to_record(instance) for instance in self._instances()]
+        rows.sort(key=lambda row: row.last_seen_at, reverse=True)
+        return rows[skip : skip + limit]
+
+    def get(self, anomaly_id: str) -> AnomalyRecord | None:
+        self._ensure_templates()
+        for instance in self._instances():
+            if instance.euid == anomaly_id:
+                return self._to_record(instance)
+        return None
+
+    def record_db_probe_failure(self, *, detail: str, latency_ms: float) -> AnomalyRecord:
+        return self.record(
+            category="database",
+            severity="error",
+            fingerprint=f"db:{hash(detail)}",
+            summary="Bloom database probe failed",
+            redacted_context={
+                "detail": detail,
+                "latency_ms": round(float(latency_ms), 3),
+            },
+        )
+
+    def _ensure_templates(self) -> None:
+        if self._templates_ready:
+            return
+        require_seeded_templates(
+            self.db,
+            [(ANOMALY_TEMPLATE_CODE, ANOMALY_PREFIX)],
+            app_name="Bloom",
+            template_manager=self.templates,
+        )
+        self._templates_ready = True
+
+    def _find_existing(
+        self,
+        *,
+        category: str,
+        severity: str,
+        fingerprint: str,
+        environment: str,
+    ) -> generic_instance | None:
+        for instance in self._instances():
+            props = self._props(instance)
+            if (
+                str(props.get("category") or "") == category
+                and str(props.get("severity") or "") == severity
+                and str(props.get("fingerprint") or "") == fingerprint
+                and str(props.get("environment") or "") == environment
+            ):
+                return instance
+        return None
+
+    def _instances(self) -> list[generic_instance]:
+        category, type_name, subtype, version = ANOMALY_TEMPLATE_CODE.strip("/").split("/")
+        stmt = (
+            select(generic_instance)
+            .where(
+                generic_instance.category == category,
+                generic_instance.type == type_name,
+                generic_instance.subtype == subtype,
+                generic_instance.version == version,
+                generic_instance.is_deleted.is_(False),
+            )
+            .order_by(generic_instance.created_dt.desc())
+        )
+        return list(self.db.execute(stmt).scalars())
+
+    def _props(self, instance: generic_instance) -> dict[str, Any]:
+        payload = instance.json_addl or {}
+        if not isinstance(payload, dict):
+            payload = {}
+        properties = payload.get("properties")
+        if not isinstance(properties, dict):
+            properties = {}
+            payload["properties"] = properties
+            instance.json_addl = payload
+        return properties
+
+    def _write_props(self, instance: generic_instance, properties: dict[str, Any]) -> None:
+        payload = instance.json_addl or {}
+        if not isinstance(payload, dict):
+            payload = {}
+        payload["properties"] = properties
+        instance.json_addl = payload
+        if hasattr(instance, "_sa_instance_state"):
+            flag_modified(instance, "json_addl")
+
+    def _to_record(self, instance: generic_instance) -> AnomalyRecord:
+        props = self._props(instance)
+        return AnomalyRecord(
+            id=str(instance.euid),
+            service=str(props.get("service") or "bloom"),
+            environment=str(props.get("environment") or (get_settings().environment or "unknown")),
+            category=str(props.get("category") or "unknown"),
+            severity=str(props.get("severity") or "unknown"),
+            fingerprint=str(props.get("fingerprint") or ""),
+            summary=str(props.get("summary") or ""),
+            first_seen_at=str(props.get("first_seen_at") or ""),
+            last_seen_at=str(props.get("last_seen_at") or ""),
+            occurrence_count=int(props.get("occurrence_count") or 0),
+            redacted_context=dict(props.get("redacted_context") or {}),
+            source_view_url=f"/admin/anomalies/{instance.euid}",
+        )
+
+
+def open_anomaly_repository(*, app_username: str):
+    from bloom_lims.db import BLOOMdb3
+
+    bdb = BLOOMdb3(app_username=app_username)
+    return TapdbAnomalyRepository(bdb.session), bdb

--- a/bloom_lims/gui/routes/operations.py
+++ b/bloom_lims/gui/routes/operations.py
@@ -28,6 +28,7 @@ from sqlalchemy import func
 from sqlalchemy.orm.attributes import flag_modified
 
 from auth.cognito.client import CognitoConfigurationError
+from bloom_lims.anomalies import TapdbAnomalyRepository
 from bloom_lims.bobjs import BloomFile, BloomFileReference, BloomFileSet, BloomObj
 from bloom_lims.bvars import BloomVars
 from bloom_lims.db import BLOOMdb3
@@ -462,6 +463,68 @@ async def admin_observability(request: Request, _auth=Depends(require_auth), lim
         "db_payload": db_payload,
         "auth_projection": auth_projection.model_dump(),
         "auth_payload": auth_payload,
+    }
+    return HTMLResponse(content=template.render(context))
+
+
+@router.get("/admin/anomalies", response_class=HTMLResponse)
+async def admin_anomalies(request: Request, _auth=Depends(require_auth), limit: int = 100):
+    if not _is_admin_session(request):
+        return _admin_forbidden_response(request)
+
+    user_data = request.session.get("user_data", {})
+    anomalies: list[dict] = []
+    error_detail = ""
+    bdb = BLOOMdb3(app_username=user_data.get("email", "admin-anomalies"))
+    try:
+        anomalies = [record.__dict__ for record in TapdbAnomalyRepository(bdb.session).list(limit=limit)]
+    except Exception as exc:
+        error_detail = str(exc)
+    finally:
+        bdb.close()
+
+    template = templates.get_template("modern/admin_anomalies.html")
+    context = {
+        "request": request,
+        "udat": user_data,
+        "user_data": user_data,
+        "anomaly": None,
+        "anomalies": anomalies,
+        "error_detail": error_detail,
+    }
+    return HTMLResponse(content=template.render(context))
+
+
+@router.get("/admin/anomalies/{anomaly_id}", response_class=HTMLResponse)
+async def admin_anomaly_detail(
+    anomaly_id: str,
+    request: Request,
+    _auth=Depends(require_auth),
+    limit: int = 25,
+):
+    if not _is_admin_session(request):
+        return _admin_forbidden_response(request)
+
+    user_data = request.session.get("user_data", {})
+    anomalies: list[dict] = []
+    anomaly = None
+    bdb = BLOOMdb3(app_username=user_data.get("email", "admin-anomalies"))
+    try:
+        repository = TapdbAnomalyRepository(bdb.session)
+        anomaly = repository.get(anomaly_id)
+        anomalies = [record.__dict__ for record in repository.list(limit=limit)]
+    finally:
+        bdb.close()
+    if anomaly is None:
+        raise HTTPException(status_code=404, detail="Anomaly not found")
+
+    template = templates.get_template("modern/admin_anomalies.html")
+    context = {
+        "request": request,
+        "udat": user_data,
+        "user_data": user_data,
+        "anomaly": anomaly.__dict__,
+        "anomalies": anomalies,
     }
     return HTMLResponse(content=template.render(context))
 

--- a/bloom_lims/observability.py
+++ b/bloom_lims/observability.py
@@ -150,12 +150,19 @@ class BloomObservabilityStore:
                 {"path": "/api_health", "auth": "operator_or_service_token", "kind": "api_rollup"},
                 {"path": "/endpoint_health", "auth": "operator_or_service_token", "kind": "endpoint_rollup"},
                 {"path": "/db_health", "auth": "operator_or_service_token", "kind": "database"},
+                {"path": "/api/anomalies", "auth": "operator_or_service_token", "kind": "anomaly_list"},
+                {
+                    "path": "/api/anomalies/{anomaly_id}",
+                    "auth": "operator_or_service_token",
+                    "kind": "anomaly_detail",
+                },
                 {"path": "/my_health", "auth": "authenticated_self", "kind": "self"},
                 {"path": "/auth_health", "auth": "operator_or_service_token", "kind": "auth"},
             ],
             "extensions": [
                 "bloom.admin_metrics_ui",
                 "bloom.admin_observability_ui",
+                "bloom.anomalies_v1",
             ],
             "observed_at": self._started_at,
         }

--- a/bloom_lims/observability_routes.py
+++ b/bloom_lims/observability_routes.py
@@ -5,6 +5,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from bloom_lims.anomalies import TapdbAnomalyRepository
 from bloom_lims.api.v1.dependencies import APIUser, get_api_user, require_api_auth
 from bloom_lims.health import check_database_health
 from bloom_lims.observability import (
@@ -15,6 +16,7 @@ from bloom_lims.observability import (
     build_my_health_payload,
     build_obs_services_payload,
 )
+from bloom_lims.tapdb_adapter import BLOOMdb3
 
 
 router = APIRouter(tags=["Health"])
@@ -27,6 +29,13 @@ def _record_auth(request: Request, user: APIUser) -> None:
         detail=request.url.path,
         service_principal=user.auth_source == "legacy_api_key",
     )
+
+
+def _anomaly_repository(app_username: str) -> tuple[BLOOMdb3, TapdbAnomalyRepository]:
+    bdb = BLOOMdb3(app_username=app_username)
+    return bdb, TapdbAnomalyRepository(bdb.session)
+
+
 @router.get("/obs_services")
 async def obs_services(
     request: Request,
@@ -80,10 +89,67 @@ async def db_health(
         latency_ms=float(db_component.latency_ms or ((monotonic() - started) * 1000)),
         detail=str(db_component.message or ""),
     )
+    if db_component.status != "healthy":
+        bdb, repository = _anomaly_repository(getattr(user, "email", "") or "observability")
+        try:
+            repository.record_db_probe_failure(
+                detail=str(db_component.message or ""),
+                latency_ms=float(db_component.latency_ms or ((monotonic() - started) * 1000)),
+            )
+        finally:
+            bdb.close()
     projection, payload = request.app.state.observability.db_health()
     if not payload.get("observed_at"):
         payload["observed_at"] = details.get("observed_at")
     return build_db_health_payload(request, projection=projection, db_health=payload)
+
+
+@router.get("/api/anomalies")
+async def list_anomalies(
+    request: Request,
+    user: Annotated[APIUser, Depends(require_api_auth)],
+    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=500),
+) -> dict:
+    _record_auth(request, user)
+    bdb, repository = _anomaly_repository(getattr(user, "email", "") or "api-anomalies")
+    try:
+        items = [record.__dict__ for record in repository.list(skip=offset, limit=limit)]
+        projection = repository.projection()
+    finally:
+        bdb.close()
+    return {
+        "service": "bloom",
+        "contract_version": "v3",
+        "observed_at": projection.observed_at,
+        "projection": projection.model_dump(),
+        "items": items,
+        "count": len(items),
+    }
+
+
+@router.get("/api/anomalies/{anomaly_id}")
+async def get_anomaly(
+    anomaly_id: str,
+    request: Request,
+    user: Annotated[APIUser, Depends(require_api_auth)],
+) -> dict:
+    _record_auth(request, user)
+    bdb, repository = _anomaly_repository(getattr(user, "email", "") or "api-anomalies")
+    try:
+        record = repository.get(anomaly_id)
+        projection = repository.projection()
+    finally:
+        bdb.close()
+    if record is None:
+        raise HTTPException(status_code=404, detail="Anomaly not found")
+    return {
+        "service": "bloom",
+        "contract_version": "v3",
+        "observed_at": projection.observed_at,
+        "projection": projection.model_dump(),
+        "item": record.__dict__,
+    }
 
 
 @router.get("/my_health")

--- a/templates/modern/admin.html
+++ b/templates/modern/admin.html
@@ -136,6 +136,10 @@
           <span><i class="fas fa-heart-pulse"></i> Observability</span>
           <i class="fas fa-chevron-right text-muted"></i>
         </a>
+        <a href="/admin/anomalies" class="list-item">
+          <span><i class="fas fa-triangle-exclamation"></i> Operational Anomalies</span>
+          <i class="fas fa-chevron-right text-muted"></i>
+        </a>
       </div>
     </div>
   </div>

--- a/templates/modern/admin_anomalies.html
+++ b/templates/modern/admin_anomalies.html
@@ -1,0 +1,88 @@
+{% extends "modern/base.html" %}
+{% block title %}Operational Anomalies - BLOOM LIMS{% endblock %}
+
+{% block content %}
+<div class="page-header">
+  <div>
+    <h1>Operational Anomalies</h1>
+    <p class="text-muted">Read-only anomaly records persisted for Bloom operators.</p>
+  </div>
+  <div class="btn-row">
+    <a href="/admin" class="btn btn-outline btn-sm"><i class="fas fa-arrow-left"></i> Admin</a>
+    <a href="/admin/observability" class="btn btn-outline btn-sm"><i class="fas fa-heart-pulse"></i> Observability</a>
+  </div>
+</div>
+
+<div class="grid grid-2">
+  <section class="card">
+    <div class="card-header">
+      <h2 class="card-title"><i class="fas fa-list"></i> Recent Anomalies</h2>
+    </div>
+    <div class="card-body">
+      {% if error_detail %}
+      <p class="text-muted">Anomaly store unavailable: {{ error_detail }}</p>
+      {% endif %}
+      {% if anomalies %}
+      <div class="table-container">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Severity</th>
+              <th>Category</th>
+              <th>Summary</th>
+              <th>Count</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in anomalies %}
+            <tr>
+              <td><a href="/admin/anomalies/{{ item.id }}" class="font-mono">{{ item.id }}</a></td>
+              <td>{{ item.severity }}</td>
+              <td>{{ item.category }}</td>
+              <td>{{ item.summary }}</td>
+              <td>{{ item.occurrence_count }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <p class="text-muted">No anomalies recorded.</p>
+      {% endif %}
+    </div>
+  </section>
+
+  <section class="card">
+    <div class="card-header">
+      <h2 class="card-title"><i class="fas fa-magnifying-glass"></i> Detail</h2>
+    </div>
+    <div class="card-body">
+      {% if anomaly %}
+      <div class="info-grid">
+        <div class="info-row"><span class="info-key">ID</span><span class="info-val font-mono">{{ anomaly.id }}</span></div>
+        <div class="info-row"><span class="info-key">Service</span><span class="info-val">{{ anomaly.service }}</span></div>
+        <div class="info-row"><span class="info-key">Environment</span><span class="info-val">{{ anomaly.environment }}</span></div>
+        <div class="info-row"><span class="info-key">Severity</span><span class="info-val">{{ anomaly.severity }}</span></div>
+        <div class="info-row"><span class="info-key">Category</span><span class="info-val">{{ anomaly.category }}</span></div>
+        <div class="info-row"><span class="info-key">Fingerprint</span><span class="info-val font-mono">{{ anomaly.fingerprint }}</span></div>
+        <div class="info-row"><span class="info-key">First Seen</span><span class="info-val font-mono">{{ anomaly.first_seen_at }}</span></div>
+        <div class="info-row"><span class="info-key">Last Seen</span><span class="info-val font-mono">{{ anomaly.last_seen_at }}</span></div>
+        <div class="info-row"><span class="info-key">Count</span><span class="info-val">{{ anomaly.occurrence_count }}</span></div>
+        <div class="info-row"><span class="info-key">Source View</span><span class="info-val font-mono">{{ anomaly.source_view_url }}</span></div>
+      </div>
+      <div style="margin-top: var(--spacing-md);">
+        <h3 class="section-subtitle">Summary</h3>
+        <p>{{ anomaly.summary }}</p>
+      </div>
+      <div style="margin-top: var(--spacing-md);">
+        <h3 class="section-subtitle">Redacted Context</h3>
+        <pre class="code-block">{{ anomaly.redacted_context | tojson }}</pre>
+      </div>
+      {% else %}
+      <p class="text-muted">Select an anomaly to inspect its redacted details.</p>
+      {% endif %}
+    </div>
+  </section>
+</div>
+{% endblock %}

--- a/tests/test_anomalies.py
+++ b/tests/test_anomalies.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import os
+import sys
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+os.environ["BLOOM_OAUTH"] = "no"
+os.environ["BLOOM_DEV_AUTH_BYPASS"] = "true"
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from main import app
+from bloom_lims import observability_routes
+from bloom_lims.anomalies import AnomalyRecord, TapdbAnomalyRepository
+from bloom_lims.gui.routes import operations
+
+
+class _FakeSession:
+    def add(self, _obj) -> None:
+        return None
+
+    def flush(self) -> None:
+        return None
+
+    def commit(self) -> None:
+        return None
+
+
+def _build_fake_repository() -> TapdbAnomalyRepository:
+    repository = TapdbAnomalyRepository(_FakeSession())
+    instances: list[SimpleNamespace] = []
+    counter = {"value": 0}
+
+    def create_instance(*, template_code: str, name: str, properties: dict, session) -> SimpleNamespace:
+        counter["value"] += 1
+        category, type_name, subtype, version = template_code.strip("/").split("/")
+        instance = SimpleNamespace(
+            euid=f"BAN-{counter['value']:04d}",
+            name=name,
+            json_addl={"properties": properties},
+            created_dt=datetime.now(UTC),
+            category=category,
+            type=type_name,
+            subtype=subtype,
+            version=version,
+            is_deleted=False,
+        )
+        instances.append(instance)
+        return instance
+
+    repository._ensure_templates = lambda: None  # type: ignore[method-assign]
+    repository._instances = lambda: list(instances)  # type: ignore[method-assign]
+    repository.factory = SimpleNamespace(create_instance=create_instance)
+    return repository
+
+
+def _sample_record() -> AnomalyRecord:
+    now = datetime.now(UTC).isoformat()
+    return AnomalyRecord(
+        id="BAN-0001",
+        service="bloom",
+        environment="dev",
+        category="database",
+        severity="error",
+        fingerprint="db-fingerprint",
+        summary="Bloom database probe failed",
+        first_seen_at=now,
+        last_seen_at=now,
+        occurrence_count=2,
+        redacted_context={"token": "[redacted]", "sql": "[redacted-sql]"},
+        source_view_url="/admin/anomalies/BAN-0001",
+    )
+
+
+class _StubRepository:
+    def __init__(self):
+        self._record = _sample_record()
+
+    def list(self, *, skip: int = 0, limit: int = 100):
+        return [self._record][skip : skip + limit]
+
+    def get(self, anomaly_id: str):
+        if anomaly_id == self._record.id:
+            return self._record
+        return None
+
+    def projection(self):
+        return SimpleNamespace(
+            observed_at=self._record.last_seen_at,
+            model_dump=lambda: {
+                "state": "ready",
+                "stale": False,
+                "observed_at": self._record.last_seen_at,
+                "last_synced_at": self._record.last_seen_at,
+                "detail": None,
+            },
+        )
+
+
+class _StubBloomDB:
+    def __init__(self, app_username: str = ""):
+        self.app_username = app_username
+        self.session = None
+
+    def close(self) -> None:
+        return None
+
+
+def test_anomaly_repository_upserts_and_redacts_context() -> None:
+    repository = _build_fake_repository()
+    context = {
+        "authorization": "Bearer super-secret-token",
+        "nested": {
+            "cookie": "session=abc123",
+            "path": "/documents/123456/details",
+            "sql": "SELECT * FROM users WHERE id = 123456",
+        },
+        "items": [{"password": "open-sesame"}, "/patients/987654321"],
+    }
+
+    first = repository.record(
+        category="database",
+        severity="error",
+        fingerprint="db-fingerprint",
+        summary="Bloom database probe failed",
+        redacted_context=context,
+    )
+    second = repository.record(
+        category="database",
+        severity="error",
+        fingerprint="db-fingerprint",
+        summary="Bloom database probe failed",
+        redacted_context=context,
+    )
+
+    assert first.id == second.id
+    assert len(repository.list()) == 1
+    assert second.occurrence_count == 2
+    assert second.redacted_context["authorization"] == "[redacted]"
+    assert second.redacted_context["nested"]["cookie"] == "[redacted]"
+    assert second.redacted_context["nested"]["path"] == "/documents/{id}/details"
+    assert second.redacted_context["nested"]["sql"] == "[redacted-sql]"
+    assert second.redacted_context["items"][0]["password"] == "[redacted]"
+    assert second.redacted_context["items"][1] == "/patients/{id}"
+
+
+def test_anomaly_api_lists_and_reads_records(monkeypatch) -> None:
+    monkeypatch.setattr(
+        observability_routes,
+        "_anomaly_repository",
+        lambda _app_username: (_StubBloomDB(), _StubRepository()),
+    )
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        listing = client.get("/api/anomalies")
+        detail = client.get("/api/anomalies/BAN-0001")
+        missing = client.get("/api/anomalies/BAN-DOES-NOT-EXIST")
+
+    assert listing.status_code == 200
+    payload = listing.json()
+    assert payload["service"] == "bloom"
+    assert payload["projection"]["state"] == "ready"
+    assert payload["count"] == 1
+    assert payload["items"][0]["redacted_context"]["token"] == "[redacted]"
+
+    assert detail.status_code == 200
+    assert detail.json()["item"]["id"] == "BAN-0001"
+
+    assert missing.status_code == 404
+
+
+def test_admin_anomalies_views_render(monkeypatch) -> None:
+    monkeypatch.setattr(operations, "BLOOMdb3", _StubBloomDB)
+    monkeypatch.setattr(operations, "TapdbAnomalyRepository", lambda _session: _StubRepository())
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        listing = client.get("/admin/anomalies")
+        detail = client.get("/admin/anomalies/BAN-0001")
+        missing = client.get("/admin/anomalies/BAN-DOES-NOT-EXIST")
+
+    assert listing.status_code == 200
+    assert "Operational Anomalies" in listing.text
+    assert "Bloom database probe failed" in listing.text
+
+    assert detail.status_code == 200
+    assert "BAN-0001" in detail.text
+    assert "[redacted]" in detail.text
+
+    assert missing.status_code == 404

--- a/tests/test_gui_endpoints.py
+++ b/tests/test_gui_endpoints.py
@@ -88,6 +88,12 @@ class TestMainGUIEndpoints:
         assert response.status_code == 200
         assert "/admin/observability" in response.text
 
+    def test_admin_includes_anomalies_link(self, client):
+        """Admin page includes link to operational anomalies."""
+        response = client.get("/admin")
+        assert response.status_code == 200
+        assert "/admin/anomalies" in response.text
+
     def test_admin_metrics_returns_html(self, client):
         """TapDB metrics page returns HTML."""
         response = client.get("/admin/metrics")
@@ -101,6 +107,18 @@ class TestMainGUIEndpoints:
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
         assert "Observability" in response.text
+
+    def test_admin_anomalies_returns_html(self, client):
+        """Anomaly page returns HTML."""
+        from bloom_lims.gui.routes import operations
+        from tests.test_anomalies import _StubBloomDB, _StubRepository
+
+        with patch.object(operations, "BLOOMdb3", _StubBloomDB):
+            with patch.object(operations, "TapdbAnomalyRepository", lambda _session: _StubRepository()):
+                response = client.get("/admin/anomalies")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        assert "Operational Anomalies" in response.text
 
     def test_admin_preferences_post_redirects(self, client):
         """Test admin preferences form POST succeeds and redirects."""

--- a/tests/test_observability_contract.py
+++ b/tests/test_observability_contract.py
@@ -74,9 +74,12 @@ def test_obs_services_uses_canonical_capability_vocabulary() -> None:
         "/api_health": {"auth": "operator_or_service_token", "kind": "api_rollup"},
         "/endpoint_health": {"auth": "operator_or_service_token", "kind": "endpoint_rollup"},
         "/db_health": {"auth": "operator_or_service_token", "kind": "database"},
+        "/api/anomalies": {"auth": "operator_or_service_token", "kind": "anomaly_list"},
+        "/api/anomalies/{anomaly_id}": {"auth": "operator_or_service_token", "kind": "anomaly_detail"},
         "/my_health": {"auth": "authenticated_self", "kind": "self"},
         "/auth_health": {"auth": "operator_or_service_token", "kind": "auth"},
     }
+    assert "bloom.anomalies_v1" in response.json()["extensions"]
 
 
 def test_endpoint_health_uses_route_templates_not_raw_instances() -> None:


### PR DESCRIPTION
## Summary
- add TapDB-backed Bloom anomaly persistence and read-only anomaly APIs
- add an admin anomaly view and advertise anomaly support through /obs_services
- keep existing health endpoints and TapDB admin GUI exposure unchanged

## Testing
- pytest tests/test_anomalies.py tests/test_cli.py tests/test_observability_contract.py tests/test_api_v1.py tests/test_gui_endpoints.py tests/test_graph_viewer_api.py tests/test_route_coverage_gaps_gui.py tests/test_operations_routes.py tests/test_tapdb_mount.py tests/test_api_auth_rbac.py tests/test_domain_access.py tests/test_user_api_tokens.py -q