### PR TITLE
Fix Bloom auth callback and admin group handling

### DIFF
--- a/bloom_lims/app.py
+++ b/bloom_lims/app.py
@@ -19,7 +19,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from bloom_lims.api import RateLimitMiddleware, api_v1_router
-from bloom_lims.config import get_settings
+from bloom_lims.config import atlas_webhook_secret_warning, get_settings
 from bloom_lims.domain_access import (
     build_allowed_origin_regex,
     build_trusted_hosts,
@@ -79,6 +79,9 @@ def _validate_required_config(settings) -> None:
 def create_app() -> FastAPI:
     settings = get_settings()
     _validate_required_config(settings)
+    atlas_secret_warning = atlas_webhook_secret_warning(settings)
+    if atlas_secret_warning:
+        logging.getLogger(__name__).warning(atlas_secret_warning)
     allow_local_domain_access = not settings.is_production
 
     @asynccontextmanager

--- a/bloom_lims/auth/services/groups.py
+++ b/bloom_lims/auth/services/groups.py
@@ -35,9 +35,9 @@ SYSTEM_GROUP_CODES = [
 ]
 
 GROUP_ROLE_MAP = {
-    BLOOM_READONLY_GROUP: Role.READ_ONLY.value,
-    BLOOM_READWRITE_GROUP: Role.READ_WRITE.value,
-    BLOOM_ADMIN_GROUP: Role.ADMIN.value,
+    BLOOM_READONLY_GROUP.upper(): Role.READ_ONLY.value,
+    BLOOM_READWRITE_GROUP.upper(): Role.READ_WRITE.value,
+    BLOOM_ADMIN_GROUP.upper(): Role.ADMIN.value,
 }
 
 
@@ -106,6 +106,11 @@ class GroupService:
     ) -> GroupResolution:
         fallback = map_legacy_role(fallback_role)
         groups = self.get_group_codes_for_user(user_id)
-        role_groups = [GROUP_ROLE_MAP[group] for group in groups if group in GROUP_ROLE_MAP]
+        role_groups = []
+        for group in groups:
+            normalized_group = str(group or "").strip().upper()
+            mapped_role = GROUP_ROLE_MAP.get(normalized_group)
+            if mapped_role:
+                role_groups.append(mapped_role)
         roles = normalize_roles(role_groups or [fallback], fallback=fallback)
         return GroupResolution(roles=roles, groups=sorted(groups))

--- a/bloom_lims/cli/server.py
+++ b/bloom_lims/cli/server.py
@@ -29,6 +29,7 @@ from rich.console import Console
 
 from bloom_lims.config import (
     apply_runtime_environment,
+    atlas_webhook_secret_warning,
     get_settings,
     get_tapdb_db_config,
 )
@@ -149,6 +150,15 @@ def start(
             "\n   Fix your config ([cyan]bloom config edit[/cyan]) or run [cyan]bloom db init[/cyan]."
         )
         raise typer.Exit(1)
+
+    atlas_secret_warning = atlas_webhook_secret_warning(settings)
+    if atlas_secret_warning:
+        console.print(f"[yellow]⚠[/yellow] {atlas_secret_warning}")
+        console.print(
+            "   Configure it in [cyan]~/.config/bloom/config.yaml[/cyan] under "
+            "[cyan]atlas.webhook_secret[/cyan]."
+        )
+        console.log(atlas_secret_warning)
 
     pid, _ = active_server_pid()
     if pid:

--- a/bloom_lims/config.py
+++ b/bloom_lims/config.py
@@ -10,6 +10,8 @@ Configuration precedence (highest to lowest):
 import importlib.metadata
 import logging
 import os
+import secrets
+import string
 import tempfile
 from functools import lru_cache
 from importlib import resources as importlib_resources
@@ -755,6 +757,28 @@ def assert_tapdb_version(
     return str(installed)
 
 
+def generate_example_webhook_secret(length: int = 20) -> str:
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def atlas_webhook_secret_warning(
+    settings: "BloomSettings | None" = None,
+    *,
+    suggested_secret: str | None = None,
+) -> str | None:
+    active_settings = settings or get_settings()
+    if str(active_settings.atlas.webhook_secret or "").strip():
+        return None
+    example = suggested_secret or generate_example_webhook_secret()
+    return (
+        "Atlas webhook signature secret is not configured "
+        "(atlas.webhook_secret is empty). Bloom can still start, but signed Atlas webhook "
+        "delivery and verification will not be safe or interoperable. Set a 20-character "
+        f"alphanumeric secret such as: {example}"
+    )
+
+
 def validate_settings() -> List[str]:
     """Validate settings and return list of warnings/issues."""
     warnings: List[str] = []
@@ -782,6 +806,10 @@ def validate_settings() -> List[str]:
 
     if settings.storage.s3_bucket and not os.environ.get("AWS_ACCESS_KEY_ID"):
         warnings.append("S3 bucket configured but AWS_ACCESS_KEY_ID not set")
+
+    atlas_secret_warning = atlas_webhook_secret_warning(settings)
+    if atlas_secret_warning:
+        warnings.append(atlas_secret_warning)
 
     return warnings
 

--- a/bloom_lims/docs/cognito.md
+++ b/bloom_lims/docs/cognito.md
@@ -161,7 +161,7 @@ If using Google as an identity provider:
    - **App type**: Select **Public client**
    - **App client name**: `bloom-lims-web`
    - **Client secret**: Select **Don't generate a client secret**
-     > ⚠️ **Important**: Bloom uses the implicit grant flow which does not support client secrets
+     > ⚠️ **Important**: Bloom uses the authorization-code flow and expects the Hosted UI to redirect back to `/auth/callback`
 
 5. **Allowed callback URLs**:
    ```
@@ -176,8 +176,8 @@ If using Google as an identity provider:
 
 7. **Advanced app client settings** (expand this section):
    - **OAuth 2.0 grant types**:
-     - ☑️ **Implicit grant**
-     - ☐ Authorization code grant (not used)
+     - ☐ **Implicit grant**
+     - ☑️ **Authorization code grant**
 
    - **OpenID Connect scopes**:
      - ☑️ **OpenID**
@@ -231,7 +231,7 @@ Click **Edit** under Hosted UI:
 │   ☑️ Google (if configured)                                 │
 │                                                             │
 │ OAuth 2.0 grant types:                                      │
-│   ☑️ Implicit grant                                         │
+│   ☑️ Authorization code grant                               │
 │                                                             │
 │ OpenID Connect scopes:                                      │
 │   ☑️ openid                                                 │
@@ -362,7 +362,7 @@ BLOOM uses a YAML-based configuration system. Configuration is loaded from:
        - "openid"
        - "email"
        - "profile"
-     cognito_allowed_domains: []  # Empty = allow all; or ["yourcompany.com", "partner.org"]
+     cognito_allowed_domains: []  # Empty = block all; list each allowed domain explicitly
    ```
 
 ### YAML-Only Runtime Configuration
@@ -381,7 +381,7 @@ Do not rely on `COGNITO_*`, `BLOOM_AUTH__COGNITO_*`, or daycog env files for ser
 | `auth.cognito_redirect_uri` | ✅ Yes | - | Post-login redirect URL |
 | `auth.cognito_logout_redirect_uri` | ⚠️ Recommended | Same as redirect | Post-logout redirect URL |
 | `auth.cognito_scopes` | ❌ No | `["openid", "email", "profile"]` | OAuth scopes to request |
-| `auth.cognito_allowed_domains` | ❌ No | `[]` (allow all) | Allowed email domains |
+| `auth.cognito_allowed_domains` | ❌ No | `[]` (block all) | Allowed email domains |
 
 ---
 
@@ -455,9 +455,10 @@ sequenceDiagram
     B->>U: Render login page with Cognito URL
     U->>C: Click "Login with Cognito"
     C->>C: User authenticates (email/password or Google)
-    C->>U: Redirect to auth.cognito_redirect_uri with tokens in URL fragment
-    U->>U: JavaScript extracts id_token and access_token
-    U->>B: POST /oauth_callback with tokens
+    C->>U: Redirect to auth.cognito_redirect_uri with authorization code
+    U->>B: GET /auth/callback?code=...
+    B->>C: POST /oauth2/token with code
+    C->>B: Return id_token and access_token
     B->>J: Fetch JWKS public keys
     J->>B: Return public keys
     B->>B: Validate JWT signature and claims
@@ -477,14 +478,15 @@ The authentication is handled by these components:
 
 2. **`main.py`** - Route handlers:
    - `GET /login`: Renders login page with Cognito authorize URL
-   - `POST /oauth_callback`: Validates tokens and creates session
+   - `GET /auth/callback`: Exchanges authorization code and creates session
+   - `POST /oauth_callback`: Legacy fragment-token fallback for Hosted UI responses that arrive with tokens
    - `GET /logout`: Clears session and redirects to Cognito logout
 
 3. **`templates/login.html`** - Login UI:
    - "Login with Cognito" button triggers redirect
 
-4. **`templates/index.html`** - Token handling:
-   - JavaScript extracts tokens from URL fragment
+4. **`/auth/callback` fallback page**:
+   - If Cognito returns fragment tokens instead of `?code=...`, JavaScript extracts them
    - Posts tokens to `/oauth_callback`
 
 ### Session Data Structure
@@ -786,7 +788,8 @@ def validate_token(self, token: str) -> Dict:
 | Endpoint | Description |
 |----------|-------------|
 | `GET /login` | Displays login page with Cognito button |
-| `POST /oauth_callback` | Handles token validation after Cognito redirect |
+| `GET /auth/callback` | Exchanges Cognito authorization code and completes login |
+| `POST /oauth_callback` | Handles legacy fragment-token fallback after Cognito redirect |
 | `GET /logout` | Clears session and redirects to Cognito logout |
 | `GET /user_home` | Shows user profile with Cognito details |
 

--- a/bloom_lims/gui/routes/auth.py
+++ b/bloom_lims/gui/routes/auth.py
@@ -9,7 +9,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from auth.cognito.client import CognitoConfigurationError, CognitoTokenError
 from bloom_lims.auth.rbac import Role
-from bloom_lims.auth.services.groups import GroupService
+from bloom_lims.auth.services.groups import GroupService, map_legacy_role
 from bloom_lims.db import BLOOMdb3
 from bloom_lims.gui.deps import _get_request_cognito_auth, get_allowed_domains, get_user_preferences, require_auth
 from bloom_lims.gui.errors import MissingCognitoEnvVarsException
@@ -17,6 +17,10 @@ from bloom_lims.gui.jinja import templates
 
 
 router = APIRouter()
+
+
+class SessionBootstrapError(RuntimeError):
+    """Raised when Bloom cannot establish the post-login session context."""
 
 
 @router.get("/login", include_in_schema=False)
@@ -49,6 +53,11 @@ def _login_error_redirect(error_message: str) -> RedirectResponse:
     return RedirectResponse(url=f"/login?error={quote(msg)}", status_code=303)
 
 
+def _callback_error_response(error_message: str, *, status_code: int) -> JSONResponse:
+    msg = (error_message or "authentication_failed").strip()
+    return JSONResponse(content={"detail": msg}, status_code=status_code)
+
+
 def _resolve_login_roles_and_groups(
     *,
     email: str,
@@ -57,10 +66,10 @@ def _resolve_login_roles_and_groups(
 ) -> tuple[list[str], list[str], str]:
     normalized_email = str(email or "").strip()
     normalized_sub = str(cognito_sub or "").strip()
-    fallback = map_legacy_role(fallback_role)
-
-    bdb = BLOOMdb3(app_username=normalized_email or "cognito-login")
+    bdb = None
     try:
+        fallback = map_legacy_role(fallback_role)
+        bdb = BLOOMdb3(app_username=normalized_email or "cognito-login")
         service = GroupService(bdb.session)
         service.ensure_system_groups()
 
@@ -82,9 +91,12 @@ def _resolve_login_roles_and_groups(
         return resolution.roles, resolution.groups, default_user_id
     except Exception as exc:
         logging.warning("Failed to resolve session RBAC for %s: %s", normalized_email, exc)
-        return [fallback or Role.READ_WRITE.value], [], (normalized_sub or normalized_email)
+        raise SessionBootstrapError(
+            "Bloom could not initialize your local access profile. Please try signing in again."
+        ) from exc
     finally:
-        bdb.close()
+        if bdb is not None:
+            bdb.close()
 
 
 async def _complete_cognito_login(
@@ -135,11 +147,17 @@ async def _complete_cognito_login(
             )
 
     cognito_sub = decoded_token.get("sub")
-    roles, groups, resolved_user_id = _resolve_login_roles_and_groups(
-        email=primary_email,
-        cognito_sub=cognito_sub,
-        fallback_role=None,
-    )
+    try:
+        roles, groups, resolved_user_id = _resolve_login_roles_and_groups(
+            email=primary_email,
+            cognito_sub=cognito_sub,
+            fallback_role=None,
+        )
+    except SessionBootstrapError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
     primary_role = (roles[0] if roles else Role.READ_WRITE.value).upper()
 
     user_data = get_user_preferences(primary_email)
@@ -186,6 +204,9 @@ async def oauth_callback_get(request: Request):
         except CognitoTokenError as exc:
             logging.error("Authorization code exchange failed: %s", exc)
             return _login_error_redirect(str(exc))
+        except Exception:
+            logging.exception("Unhandled error completing Cognito callback")
+            return _login_error_redirect("Unable to complete login. Please try again.")
 
     html_content = """<!DOCTYPE html>
 <html>
@@ -232,14 +253,30 @@ async def oauth_callback_get(request: Request):
 
 @router.post("/oauth_callback")
 async def oauth_callback(request: Request):
-    body = await request.json()
+    try:
+        body = await request.json()
+    except Exception:
+        logging.exception("Invalid Cognito callback payload")
+        return _callback_error_response(
+            "Invalid callback payload",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
     access_token = body.get("access_token") or body.get("accessToken")
     id_token = body.get("id_token")
-    return await _complete_cognito_login(
-        request,
-        id_token=id_token,
-        access_token=access_token,
-    )
+    try:
+        return await _complete_cognito_login(
+            request,
+            id_token=id_token,
+            access_token=access_token,
+        )
+    except HTTPException as exc:
+        return _callback_error_response(str(exc.detail), status_code=exc.status_code)
+    except Exception:
+        logging.exception("Unhandled error completing Cognito callback")
+        return _callback_error_response(
+            "Unable to complete login. Please try again.",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
 
 
 @router.get("/auth/callback")

--- a/tests/test_cognito_shared_pool_resolution.py
+++ b/tests/test_cognito_shared_pool_resolution.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -30,6 +31,19 @@ def test_from_settings_uses_yaml_only_configuration():
     assert auth.config.redirect_uri == "https://localhost:8912/auth/callback"
     assert auth.config.logout_redirect_uri == "https://localhost:8912/"
     assert auth.config.domain == "bloom.auth.us-east-1.amazoncognito.com"
+
+
+def test_authorize_url_uses_authorization_code_flow():
+    auth = CognitoAuth.from_settings(_auth_settings())
+
+    parsed = urlparse(auth.config.authorize_url)
+    query = parse_qs(parsed.query)
+
+    assert parsed.path == "/oauth2/authorize"
+    assert query["response_type"] == ["code"]
+    assert query["redirect_uri"] == ["https://localhost:8912/auth/callback"]
+    assert query["scope"] == ["openid email profile"]
+
 
 def test_from_settings_rejects_missing_yaml_values():
     with pytest.raises(CognitoConfigurationError) as exc:

--- a/tests/test_config_runtime.py
+++ b/tests/test_config_runtime.py
@@ -6,8 +6,17 @@ import os
 import tempfile
 from pathlib import Path
 
+import logging
+
 from bloom_lims.app import create_app
-from bloom_lims.config import BloomSettings, StorageSettings, get_settings
+from bloom_lims.config import (
+    BloomSettings,
+    StorageSettings,
+    atlas_webhook_secret_warning,
+    generate_example_webhook_secret,
+    get_settings,
+    validate_settings,
+)
 from tests.support.runtime import ensure_test_runtime_environment
 
 
@@ -65,3 +74,38 @@ def test_strict_app_startup_accepts_synthesized_test_config(
     app = create_app()
 
     assert app.title == "FastAPI"
+
+
+def test_generate_example_webhook_secret_is_20_char_alphanumeric():
+    secret = generate_example_webhook_secret()
+    assert len(secret) == 20
+    assert secret.isalnum()
+
+
+def test_validate_settings_warns_when_atlas_webhook_secret_missing(monkeypatch):
+    monkeypatch.setenv("BLOOM_ATLAS__WEBHOOK_SECRET", "")
+    get_settings.cache_clear()
+
+    warnings = validate_settings()
+
+    assert any("Atlas webhook signature secret is not configured" in warning for warning in warnings)
+    assert any("20-character alphanumeric secret" in warning for warning in warnings)
+
+
+def test_create_app_logs_atlas_webhook_secret_warning(monkeypatch, tmp_path: Path, caplog):
+    monkeypatch.delenv("BLOOM_SKIP_STARTUP_VALIDATION", raising=False)
+    monkeypatch.setenv(
+        "TAPDB_CONFIG_PATH", str(tmp_path / "missing-startup-config.yaml")
+    )
+    monkeypatch.setenv("BLOOM_ATLAS__WEBHOOK_SECRET", "")
+
+    ensure_test_runtime_environment()
+    get_settings.cache_clear()
+    caplog.set_level(logging.WARNING)
+
+    create_app()
+
+    assert any(
+        "Atlas webhook signature secret is not configured" in message
+        for message in caplog.messages
+    )

--- a/tests/test_group_service_rbac.py
+++ b/tests/test_group_service_rbac.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from bloom_lims.auth.services.groups import GroupService
+
+
+def test_resolve_user_roles_and_groups_maps_uppercase_system_group_codes(monkeypatch):
+    service = GroupService(db=None)  # type: ignore[arg-type]
+    monkeypatch.setattr(
+        GroupService,
+        "get_group_codes_for_user",
+        lambda self, user_id: ["BLOOM-ADMIN"],
+    )
+
+    resolution = service.resolve_user_roles_and_groups(
+        user_id="johnm@lsmc.com",
+        fallback_role=None,
+    )
+
+    assert resolution.roles == ["ADMIN"]
+    assert resolution.groups == ["BLOOM-ADMIN"]

--- a/tests/test_gui_auth_callback.py
+++ b/tests/test_gui_auth_callback.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("BLOOM_DEV_AUTH_BYPASS", "true")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import main
+from auth.cognito.client import CognitoTokenError
+from bloom_lims.gui.routes.auth import SessionBootstrapError
+
+
+class _FakeCognitoAuth:
+    def __init__(self, *, payload: dict | None = None, exchange_error: Exception | None = None):
+        self._payload = payload or {}
+        self._exchange_error = exchange_error
+
+    def exchange_authorization_code(self, code: str) -> dict:
+        assert code == "auth-code"
+        if self._exchange_error is not None:
+            raise self._exchange_error
+        return dict(self._payload)
+
+    def validate_token(self, token: str) -> dict:
+        assert token == "id-token-123"
+        return {
+            "email": "johnm@lsmc.com",
+            "sub": "sub-123",
+            "name": "John M",
+            "cognito:username": "johnm@lsmc.com",
+        }
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(main.app, raise_server_exceptions=False)
+
+
+def test_auth_callback_get_completes_login(monkeypatch: pytest.MonkeyPatch, client: TestClient) -> None:
+    monkeypatch.setattr(
+        "bloom_lims.gui.routes.auth._get_request_cognito_auth",
+        lambda _request: _FakeCognitoAuth(
+            payload={"id_token": "id-token-123", "access_token": "access-token-456"}
+        ),
+    )
+    monkeypatch.setattr("bloom_lims.gui.routes.auth.get_allowed_domains", lambda: ["lsmc.com"])
+    monkeypatch.setattr(
+        "bloom_lims.gui.routes.auth._resolve_login_roles_and_groups",
+        lambda **_kwargs: (["ADMIN"], ["bloom-admin"], "sub-123"),
+    )
+    monkeypatch.setattr(
+        "bloom_lims.gui.routes.auth.get_user_preferences",
+        lambda email: {"email": email, "display_timezone": "UTC"},
+    )
+
+    response = client.get("/auth/callback?code=auth-code", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/"
+    assert client.cookies.get("session")
+
+
+def test_auth_callback_get_redirects_when_rbac_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    monkeypatch.setattr(
+        "bloom_lims.gui.routes.auth._get_request_cognito_auth",
+        lambda _request: _FakeCognitoAuth(
+            payload={"id_token": "id-token-123", "access_token": "access-token-456"}
+        ),
+    )
+    monkeypatch.setattr("bloom_lims.gui.routes.auth.get_allowed_domains", lambda: ["lsmc.com"])
+    monkeypatch.setattr(
+        "bloom_lims.gui.routes.auth.BLOOMdb3",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("tapdb unavailable")),
+    )
+    monkeypatch.setattr(
+        "bloom_lims.gui.routes.auth.get_user_preferences",
+        lambda email: {"email": email, "display_timezone": "UTC"},
+    )
+
+    response = client.get("/auth/callback?code=auth-code", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/login?error=")
+    assert "local%20access%20profile" in response.headers["location"]
+
+
+def test_auth_callback_get_redirects_when_session_bootstrap_fails(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    monkeypatch.setattr(
+        "bloom_lims.gui.routes.auth._get_request_cognito_auth",
+        lambda _request: _FakeCognitoAuth(
+            payload={"id_token": "id-token-123", "access_token": "access-token-456"}
+        ),
+    )
+    monkeypatch.setattr("bloom_lims.gui.routes.auth.get_allowed_domains", lambda: ["lsmc.com"])
+    monkeypatch.setattr(
+        "bloom_lims.gui.routes.auth._resolve_login_roles_and_groups",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            SessionBootstrapError(
+                "Bloom could not initialize your local access profile. Please try signing in again."
+            )
+        ),
+    )
+
+    response = client.get("/auth/callback?code=auth-code", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/login?error=")
+    assert "local%20access%20profile" in response.headers["location"]
+
+
+def test_auth_callback_get_redirects_exchange_errors(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    monkeypatch.setattr(
+        "bloom_lims.gui.routes.auth._get_request_cognito_auth",
+        lambda _request: _FakeCognitoAuth(exchange_error=CognitoTokenError("code exchange failed")),
+    )
+
+    response = client.get("/auth/callback?code=auth-code", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"].endswith("code%20exchange%20failed")
+
+
+def test_auth_callback_get_unexpected_error_redirects_cleanly(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    async def _explode(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "bloom_lims.gui.routes.auth._get_request_cognito_auth",
+        lambda _request: _FakeCognitoAuth(
+            payload={"id_token": "id-token-123", "access_token": "access-token-456"}
+        ),
+    )
+    monkeypatch.setattr("bloom_lims.gui.routes.auth._complete_cognito_login", _explode)
+
+    response = client.get("/auth/callback?code=auth-code", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/login?error=")
+    assert response.headers["location"].endswith(
+        "Unable%20to%20complete%20login.%20Please%20try%20again."
+    )
+
+
+def test_auth_callback_post_requires_tokens(client: TestClient) -> None:
+    response = client.post("/auth/callback", json={})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "No Cognito tokens provided."}
+
+
+def test_auth_callback_post_invalid_json_returns_clean_error(client: TestClient) -> None:
+    response = client.post(
+        "/auth/callback",
+        content="{not-json",
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid callback payload"}
+
+
+def test_auth_callback_post_unexpected_error_returns_service_unavailable(
+    monkeypatch: pytest.MonkeyPatch, client: TestClient
+) -> None:
+    async def _explode(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("bloom_lims.gui.routes.auth._complete_cognito_login", _explode)
+
+    response = client.post("/auth/callback", json={"id_token": "id-token-123"})
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Unable to complete login. Please try again."}
+
+
+def test_empty_allowed_domain_config_blocks_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "bloom_lims.config.get_settings",
+        lambda: SimpleNamespace(auth=SimpleNamespace(cognito_allowed_domains=[])),
+    )
+
+    from bloom_lims.gui.deps import get_allowed_domains
+
+    assert get_allowed_domains() == ["__BLOCK_ALL__"]

--- a/tests/test_gui_endpoints.py
+++ b/tests/test_gui_endpoints.py
@@ -46,7 +46,8 @@ class TestPublicEndpoints:
     def test_login_page(self, client):
         """Test login page returns HTML."""
         response = client.get("/login")
-        assert response.status_code in [200, 401]
+        assert response.status_code == 200
+        assert "#auth-disabled" in response.text
 
     def test_help_page(self, client):
         """Test help page returns HTML."""
@@ -1332,13 +1333,14 @@ class TestOAuthEndpoints:
     def test_oauth_callback_get_without_code(self, client):
         """Test OAuth callback GET without authorization code."""
         response = client.get("/oauth_callback")
-        # Should handle missing code gracefully
-        assert response.status_code in [200, 302, 307, 400, 422]
+        assert response.status_code == 200
+        assert "Processing your login" in response.text
 
     def test_oauth_callback_post_without_code(self, client):
         """Test OAuth callback POST without authorization code."""
         response = client.post("/oauth_callback", json={})
-        assert response.status_code in [200, 302, 307, 400, 422]
+        assert response.status_code == 400
+        assert response.json() == {"detail": "No Cognito tokens provided."}
 
 
 class TestLoginPostEndpoint:
@@ -1347,14 +1349,14 @@ class TestLoginPostEndpoint:
     def test_login_post_without_email(self, client):
         """Test login POST without email."""
         response = client.post("/login", data={})
-        # Should handle missing email
-        assert response.status_code in [200, 302, 307, 400, 422]
+        assert response.status_code == 400
+        assert response.json()["message"].startswith("Direct login is disabled")
 
     def test_login_post_with_email(self, client):
         """Test login POST with email."""
         response = client.post("/login", data={"email": "test@example.com"})
-        # Should redirect to OAuth or handle login
-        assert response.status_code in [200, 302, 307, 400, 422]
+        assert response.status_code == 400
+        assert response.json()["message"].startswith("Direct login is disabled")
 
 
 class TestPlateVisualizationEndpoints:
@@ -1943,12 +1945,14 @@ class TestOAuthEndpoints:
     def test_oauth_callback_get(self, client):
         """Test OAuth callback GET endpoint."""
         response = client.get("/oauth_callback")
-        assert response.status_code in [200, 302, 307, 400, 401, 404, 422, 500]
+        assert response.status_code == 200
+        assert "Processing your login" in response.text
 
     def test_oauth_callback_post(self, client):
         """Test OAuth callback POST endpoint."""
         response = client.post("/oauth_callback", json={})
-        assert response.status_code in [200, 302, 307, 400, 401, 404, 422, 500]
+        assert response.status_code == 400
+        assert response.json() == {"detail": "No Cognito tokens provided."}
 
 
 class TestAdditionalViewEndpoints:


### PR DESCRIPTION
## Summary
- harden the Hosted UI callback flow so post-login bootstrap failures redirect cleanly instead of 500ing
- normalize uppercase Bloom admin groups and add regression coverage for admin token UI access
- document the authorization-code flow and warn clearly when the Atlas webhook secret is missing

## Testing
- pytest --no-cov tests/test_gui_auth_callback.py tests/test_group_service_rbac.py tests/test_config_runtime.py tests/test_cognito_shared_pool_resolution.py tests/test_gui_endpoints.py