### PR TITLE
Add bloom db nuke command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ bloom server start --port 8912
 
 The supported local workflow is CLI-first and uses Bloom’s own environment/bootstrap path.
 
+Delete-only teardown is also available:
+
+```bash
+bloom db nuke
+bloom db nuke --force
+```
+
 ## Architecture
 
 ### Technology
@@ -118,6 +125,7 @@ Approximate only.
 - Use `bloom ...` as the main operational interface
 - Use `tapdb ...` only for shared DB/runtime work Bloom explicitly delegates
 - Use `daycog ...` only for shared Cognito work Bloom explicitly delegates
+- `bloom db reset` rebuilds after deletion; `bloom db nuke` stops after the destructive schema reset
 
 Useful checks:
 
@@ -130,7 +138,7 @@ pytest -q
 ## Sandboxing
 
 - Safe: docs work, code reading, tests, `bloom --help`, and local-only validation against disposable local runtimes
-- Local-stateful: `bloom db init` and `bloom db seed`
+- Local-stateful: `bloom db init`, `bloom db seed`, `bloom db reset`, and `bloom db nuke`
 - Requires extra care: Cognito lifecycle, external tracking integrations, printer integrations, and any Dayhoff-managed deployed environment flows
 
 ## Current Docs

--- a/bloom_lims/cli/db.py
+++ b/bloom_lims/cli/db.py
@@ -308,6 +308,17 @@ def db_reset(
     _seed_tapdb_templates(env_name, include_workflow=False, overwrite=True)
 
 
+@db_app.command("nuke")
+def db_nuke(
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Force destructive schema reset"
+    ),
+) -> None:
+    """Delete schema only via TapDB."""
+    env_name = _current_env()
+    _run_tapdb(["db", "schema", "reset", env_name] + (["--force"] if force else []))
+
+
 def register(registry: CommandRegistry, spec: CliSpec) -> None:
     """cli-core-yo plugin: register the db command group."""
     registry.add_typer_app(None, db_app, "db", "Database management commands.")

--- a/docs/TAPDB_CLI_SPECIFICATION.md
+++ b/docs/TAPDB_CLI_SPECIFICATION.md
@@ -79,6 +79,9 @@ Bloom keeps only Bloom-specific DB commands:
 - `bloom db init`
 - `bloom db seed`
 - `bloom db reset`
+- `bloom db nuke`
+
+`bloom db nuke` is a delete-only passthrough to `tapdb db schema reset` and does not seed, setup, init pg, or start pg.
 
 Use `tapdb ...` directly for shared runtime/schema/database lifecycle. Use `daycog ...` directly for Cognito pool/app/user lifecycle.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,8 @@ from bloom_lims.cli import (
     _enforce_conda_env_contract,
     _strip_skip_conda_env_check_flag,
     build_app,
+    config_extra,
 )
-from bloom_lims.cli import config_extra
 
 server_commands = importlib.import_module("bloom_lims.cli.server")
 
@@ -100,6 +100,7 @@ class TestMainCommands:
         assert "init" in result.output
         assert "seed" in result.output
         assert "reset" in result.output
+        assert "nuke" in result.output
         assert "start" not in result.output
         assert "stop" not in result.output
         assert "status" not in result.output

--- a/tests/test_cli_db_command_paths.py
+++ b/tests/test_cli_db_command_paths.py
@@ -9,8 +9,8 @@ from types import SimpleNamespace
 import pytest
 from typer.testing import CliRunner
 
-from bloom_lims.config import DEFAULT_BLOOM_TAPDB_LOCAL_PG_PORT, DEFAULT_BLOOM_WEB_PORT
 from bloom_lims.cli import build_app
+from bloom_lims.config import DEFAULT_BLOOM_TAPDB_LOCAL_PG_PORT, DEFAULT_BLOOM_WEB_PORT
 
 db_commands = importlib.import_module("bloom_lims.cli.db")
 
@@ -181,3 +181,34 @@ def test_db_seed_calls_tapdb_template_loader(
     result = runner.invoke(cli_app, ["db", "seed"])
     assert result.exit_code == 0
     assert tapdb_seed == [("dev", False, False)]
+
+
+@pytest.mark.parametrize(
+    ("force", "expected_args"),
+    [
+        (False, ["db", "schema", "reset", "dev"]),
+        (True, ["db", "schema", "reset", "dev", "--force"]),
+    ],
+)
+def test_db_nuke_calls_tapdb_schema_reset(
+    runner: CliRunner,
+    cli_app,
+    monkeypatch: pytest.MonkeyPatch,
+    force: bool,
+    expected_args: list[str],
+) -> None:
+    calls: list[tuple[list[str], bool]] = []
+    monkeypatch.setattr(db_commands, "_current_env", lambda: "dev")
+    monkeypatch.setattr(
+        db_commands,
+        "_run_tapdb",
+        lambda args, check=True: calls.append((args, check)) or 0,
+    )
+
+    argv = ["db", "nuke"]
+    if force:
+        argv.append("--force")
+
+    result = runner.invoke(cli_app, argv)
+    assert result.exit_code == 0
+    assert calls == [(expected_args, True)]


### PR DESCRIPTION
## Summary
- add `bloom db nuke` as a delete-only TapDB passthrough
- cover the new command in CLI tests
- document the nuke/reset distinction

## Testing
- source ./activate && pytest --no-cov tests/test_cli.py tests/test_cli_db_command_paths.py