### PR TITLE
[codex] Require explicit deploy-name activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 Always start by activating the repo environment:
 
 ```bash
-source ./activate
+source ./activate <deploy-name>
 ```
 
 ## Command Ownership
@@ -23,7 +23,7 @@ source ./activate
 
 ## Bloom Examples
 
-- Start with `source ./activate`
+- Start with `source ./activate <deploy-name>`
 - Use `bloom db init`
 - Use `bloom db seed`
 - Use `bloom server start --port 8912`

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ flowchart LR
 ### Quickstart
 
 ```bash
-source ./activate
+source ./activate <deploy-name>
 bloom db init
 bloom db seed
 bloom server start --port 8912
@@ -121,7 +121,7 @@ Approximate only.
 
 ## Development Notes
 
-- Canonical local entry path: `source ./activate`
+- Canonical local entry path: `source ./activate <deploy-name>`
 - Use `bloom ...` as the main operational interface
 - Use `tapdb ...` only for shared DB/runtime work Bloom explicitly delegates
 - Use `daycog ...` only for shared Cognito work Bloom explicitly delegates
@@ -130,7 +130,7 @@ Approximate only.
 Useful checks:
 
 ```bash
-source ./activate
+source ./activate <deploy-name>
 bloom --help
 pytest -q
 ```

--- a/README.md.bland
+++ b/README.md.bland
@@ -91,7 +91,7 @@ Mounted-mode rules:
 Typical local flow:
 
 ```bash
-source ./activate
+source ./activate <deploy-name>
 pip install -e .
 bloom db build
 bloom server start --foreground
@@ -100,7 +100,7 @@ bloom server start --foreground
 Focused validation commands:
 
 ```bash
-source ./activate
+source ./activate <deploy-name>
 pytest --no-cov tests/test_api_atlas_bridge.py tests/test_atlas_lookup_resilience.py tests/test_queue_flow.py tests/test_run_resolver.py tests/test_beta_cross_repo_smoke.py
 ruff check bloom_lims tests
 ```

--- a/activate
+++ b/activate
@@ -5,7 +5,7 @@
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     echo "Error: This script must be sourced, not executed."
-    echo "Usage: source ./activate"
+    echo "Usage: source ./activate <deploy-name>"
     exit 1
 fi
 
@@ -50,11 +50,19 @@ _bloom_default_tapdb_local_pg_port() {
 _bloom_sanitize_deployment_code() {
     local raw_value="$1"
     local sanitized=""
-    sanitized="$(printf '%s' "$raw_value" | LC_ALL=C sed -E 's/[^A-Za-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+    sanitized="$(printf '%s' "$raw_value" | LC_ALL=C sed -E 's/[^A-Za-z0-9-]+/-/g; s/^-+//; s/-+$//')"
     if [[ -z "$sanitized" ]]; then
         sanitized="local"
     fi
     printf '%s\n' "$sanitized"
+}
+
+_bloom_validate_deploy_name() {
+    local deploy_name="$1"
+    if [[ ! "$deploy_name" =~ ^[A-Za-z0-9-]{2,8}$ ]]; then
+        echo -e "  ${_YELLOW}⚠${_NC} deploy-name must match ^[A-Za-z0-9-]{2,8}$"
+        return 1
+    fi
 }
 
 _bloom_prepare_tapdb_config_path() {
@@ -89,8 +97,19 @@ _bloom_prepare_tapdb_config_path() {
     printf '%s\n' "$user_path"
 }
 
-_bloom_deployment_code="${BLOOM_DEPLOYMENT_CODE:-${DEPLOYMENT_CODE:-${LSMC_DEPLOYMENT_CODE:-local}}}"
-_bloom_deployment_code="$(_bloom_sanitize_deployment_code "${_bloom_deployment_code}")"
+if [[ "$#" -ne 1 ]]; then
+    echo -e "  ${_YELLOW}⚠${_NC} Bloom activation requires exactly one positional deploy-name."
+    echo "Usage: source ./activate <deploy-name>"
+    return 1
+fi
+
+_bloom_deployment_code="$1"
+if ! _bloom_validate_deploy_name "${_bloom_deployment_code}"; then
+    return 1
+fi
+export BLOOM_DEPLOYMENT_CODE="${_bloom_deployment_code}"
+export DEPLOYMENT_CODE="${_bloom_deployment_code}"
+export LSMC_DEPLOYMENT_CODE="${_bloom_deployment_code}"
 _BLOOM_CONDA_ENV_NAME="${_BLOOM_CONDA_ENV_BASE}-${_bloom_deployment_code}"
 unset _bloom_deployment_code
 
@@ -225,7 +244,7 @@ fi
 
 if [[ "${CONDA_DEFAULT_ENV:-}" != "${_BLOOM_CONDA_ENV_NAME}" ]] || [[ -z "${CONDA_PREFIX:-}" ]] || [[ ! -x "${CONDA_PREFIX}/bin/python" ]]; then
     echo -e "  ${_YELLOW}⚠${_NC} ${_BLOOM_CONDA_ENV_NAME} conda environment is required."
-    echo -e "  ${_CYAN}→${_NC} Run 'conda env create -n ${_BLOOM_CONDA_ENV_NAME} -f bloom_env.yaml' if needed, then retry 'source ./activate'."
+    echo -e "  ${_CYAN}→${_NC} Run 'conda env create -n ${_BLOOM_CONDA_ENV_NAME} -f bloom_env.yaml' if needed, then retry 'source ./activate <deploy-name>'."
     return 1
 fi
 
@@ -335,6 +354,9 @@ export BLOOM_ROOT
 
 deactivate_bloom() {
     unset BLOOM_ROOT
+    unset BLOOM_DEPLOYMENT_CODE
+    unset DEPLOYMENT_CODE
+    unset LSMC_DEPLOYMENT_CODE
     unset TAPDB_ENV
     unset TAPDB_CLIENT_ID
     unset TAPDB_DATABASE_NAME
@@ -346,7 +368,7 @@ deactivate_bloom() {
     unset TAPDB_DEV_PORT
     unset TAPDB_TEST_PORT
     unset BLOOM_COGNITO_APP_NAME
-    if [[ "$CONDA_DEFAULT_ENV" == "BLOOM" ]]; then
+    if [[ "${CONDA_DEFAULT_ENV:-}" == "${_BLOOM_CONDA_ENV_NAME}" ]]; then
         conda deactivate 2>/dev/null
     fi
     echo "BLOOM LIMS environment deactivated."

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -51,7 +51,7 @@ docker-compose up -d
 
 ```bash
 # If using conda, Metabase can run alongside BLOOM
-source ./activate
+source ./activate <deploy-name>
 ./analytics/metabase/run_metabase.sh
 ```
 

--- a/bloom_lims/bin/init_new_ubuntu22_ec2.sh
+++ b/bloom_lims/bin/init_new_ubuntu22_ec2.sh
@@ -69,7 +69,13 @@ cd ~/projects/git/bloom/
 
 
 # Activate the BLOOM environment and initialize TapDB-managed runtime/database.
-source ./activate
+DEPLOY_NAME="${1:-${BLOOM_DEPLOYMENT_CODE:-}}"
+if [[ -z "${DEPLOY_NAME}" ]]; then
+  echo "Usage: $0 <deploy-name>" >&2
+  exit 1
+fi
+
+source ./activate "${DEPLOY_NAME}"
 export BLOOM_DEFAULT_WEB_PORT="$(python -c 'from bloom_lims.config import DEFAULT_BLOOM_WEB_PORT; print(DEFAULT_BLOOM_WEB_PORT)')"
 bloom db init --force
 
@@ -80,7 +86,7 @@ pytest  # You should get mostly successes, and some warnings (which are fine)
 # The DB is running, we can now start the UI
 # Open a tmux session which can be detached and reattached to later.
 tmux new -s bloom
-source ./activate
+source ./activate "${DEPLOY_NAME}"
 bloom server start  # or: source run_bloomui.sh (edit gunicorn command for external IP)
 # ctrl-b d to detach from the tmux session
 # this will run, logging to stdout.  

--- a/bloom_lims/bin/kick_bloom.sh
+++ b/bloom_lims/bin/kick_bloom.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source ./activate
+DEPLOY_NAME="${1:-${BLOOM_DEPLOYMENT_CODE:-}}"
+if [[ -z "${DEPLOY_NAME}" ]]; then
+  echo "Usage: $0 <deploy-name>" >&2
+  exit 1
+fi
+
+source ./activate "${DEPLOY_NAME}"
 
 # TapDB-managed reset + setup + seed for local development.
 bloom server stop || true

--- a/bloom_lims/bin/start_postgres_shell.sh
+++ b/bloom_lims/bin/start_postgres_shell.sh
@@ -1,5 +1,5 @@
 # source me
-# NOTE: Run 'source ./activate' first if not already activated
+# NOTE: Run 'source ./activate <deploy-name>' first if not already activated
 
 PGDATA=bloom_lims/database/bloom_lims
 PGUSER=$USER

--- a/bloom_lims/config.py
+++ b/bloom_lims/config.py
@@ -41,7 +41,7 @@ TEMPLATE_CONFIG_FILE = (
 
 def _sanitize_deployment_code(value: str) -> str:
     cleaned = str(value or "").strip()
-    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", cleaned)
+    cleaned = re.sub(r"[^A-Za-z0-9-]+", "-", cleaned)
     cleaned = cleaned.strip("-")
     return cleaned or "local"
 

--- a/bloom_lims/docs/cognito.md
+++ b/bloom_lims/docs/cognito.md
@@ -398,7 +398,7 @@ Do not rely on `COGNITO_*`, `BLOOM_AUTH__COGNITO_*`, or daycog env files for ser
 3. **Activate the environment and start the application**:
 
    ```bash
-   source ./activate
+   source ./activate <deploy-name>
    bloom server start
    ```
 

--- a/bloom_lims/env/install_pgadmin.sh
+++ b/bloom_lims/env/install_pgadmin.sh
@@ -1,6 +1,6 @@
 
 # SOURCE ME FROM BASH
-# This script is meant to be run from the root of the repo after running: source ./activate
+# This script is meant to be run from the root of the repo after running: source ./activate <deploy-name>
 # It will install pgadmin4 and create the necessary directories for it to run
 # https://www.pgadmin.org/download/pgadmin-4-python/
 
@@ -8,8 +8,8 @@ echo "Installing pgadmin4 to conda BLOOM env.  You will require sudo access to c
 sleep 2
 
 # Verify BLOOM environment is active
-if [[ "$CONDA_DEFAULT_ENV" != "BLOOM" ]]; then
-    echo "\n\n\n\n\n\tERROR\n\t\t BLOOM conda environment not active. Run 'source ./activate' first.\n"
+if [[ "${CONDA_DEFAULT_ENV:-}" != BLOOM-* ]]; then
+    echo "\n\n\n\n\n\tERROR\n\t\t BLOOM conda environment not active. Run 'source ./activate <deploy-name>' first.\n"
     sleep 3
     return 1
 fi

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -72,6 +72,6 @@ tapdb:
 ## Start Bloom
 
 ```bash
-source ./activate
+source ./activate <deploy-name>
 bloom server start
 ```

--- a/docs/bloom_final_completion_report.md
+++ b/docs/bloom_final_completion_report.md
@@ -55,23 +55,23 @@ Yes. Archival workflow/workset code remains in-repo but is isolated from mounted
 
 Executed exactly as requested:
 
-- `source ./activate >/dev/null 2>&1 && pytest tests/test_api_v1.py tests/test_gui_endpoints.py`
+- `source ./activate <deploy-name> >/dev/null 2>&1 && pytest tests/test_api_v1.py tests/test_gui_endpoints.py`
   - Functional result: `338 passed, 28 skipped`
   - Exit code non-zero due coverage gate (`fail_under=39`, total `30.96%`).
-- `source ./activate >/dev/null 2>&1 && pytest tests/test_action_execution.py`
+- `source ./activate <deploy-name> >/dev/null 2>&1 && pytest tests/test_action_execution.py`
   - Functional result: `2 passed`
   - Exit code non-zero due coverage gate (`7.99%`).
-- `source ./activate >/dev/null 2>&1 && pytest tests/test_admin_auth.py tests/test_user_api_tokens.py`
+- `source ./activate <deploy-name> >/dev/null 2>&1 && pytest tests/test_admin_auth.py tests/test_user_api_tokens.py`
   - Functional result: `4 passed`
   - Exit code non-zero due coverage gate (`23.19%`).
-- `source ./activate >/dev/null 2>&1 && pytest tests/test_external_specimens.py tests/test_beta_lab.py`
+- `source ./activate <deploy-name> >/dev/null 2>&1 && pytest tests/test_external_specimens.py tests/test_beta_lab.py`
   - Functional result: `5 passed`
   - Exit code non-zero due coverage gate (`20.93%`).
-- `source ./activate >/dev/null 2>&1 && pytest tests/test_operations_routes.py -k zebra`
+- `source ./activate <deploy-name> >/dev/null 2>&1 && pytest tests/test_operations_routes.py -k zebra`
   - Functional result: `2 passed, 2 deselected`
   - Exit code non-zero due coverage gate (`20.68%`).
 
 Additional check run:
 
-- `source ./activate >/dev/null 2>&1 && ruff check bloom_lims tests`
+- `source ./activate <deploy-name> >/dev/null 2>&1 && ruff check bloom_lims tests`
   - Non-green due large pre-existing repo baseline violations.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def _ensure_db_backed_integration_runtime(pytestconfig):
         pytest.exit(
             "BLOOM integration test bootstrap failed. "
             f"{exc} "
-            "Retry after `source ./activate && bloom db init`.",
+            "Retry after `source ./activate <deploy-name> && bloom db init`.",
             returncode=2,
         )
 

--- a/tests/support/runtime.py
+++ b/tests/support/runtime.py
@@ -173,7 +173,7 @@ def ensure_local_tapdb_ready(*, env_name: str = "dev") -> bool:
     if not tapdb_local_available(env_name=env_name):
         raise RuntimeError(
             "Local TapDB is still unavailable after `bloom db init`. "
-            "Fix the runtime and retry `source ./activate && bloom db init`."
+            "Fix the runtime and retry `source ./activate <deploy-name> && bloom db init`."
         )
 
     return True


### PR DESCRIPTION
## Summary
- require `source ./activate <deploy-name>` for Bloom activation
- validate deploy names as `^[A-Za-z0-9-]{2,8}$` and fail hard on missing, invalid, or extra args
- update helper scripts and docs to use the explicit deploy-name contract

## Validation
- `bash --noprofile --norc -c 'source ./activate'` (fails as expected)
- `bash --noprofile --norc -c 'source ./activate bad_name'` (fails as expected)
- `bash --noprofile --norc -c 'source ./activate ab-12cd extra'` (fails as expected)
