### PR TITLE
[codex] Hard-cut Bloom TapDB config and observability cleanup

### DIFF
--- a/activate
+++ b/activate
@@ -315,10 +315,9 @@ _BLOOM_TAPDB_DATABASE_NAME="bloom"
 export MERIDIAN_ENVIRONMENT="${MERIDIAN_ENVIRONMENT:-production}"
 export MERIDIAN_SANDBOX_PREFIX="${MERIDIAN_SANDBOX_PREFIX-}"
 export BLOOM_UI_PORT="${BLOOM_UI_PORT:-$(_bloom_default_web_port)}"
-export BLOOM_TAPDB_LOCAL_PG_PORT="${BLOOM_TAPDB_LOCAL_PG_PORT:-$(_bloom_default_tapdb_local_pg_port)}"
-export BLOOM_TAPDB_DEV_PORT="${BLOOM_TAPDB_DEV_PORT:-$BLOOM_TAPDB_LOCAL_PG_PORT}"
-export BLOOM_TAPDB_TEST_PORT="${BLOOM_TAPDB_TEST_PORT:-$BLOOM_TAPDB_LOCAL_PG_PORT}"
-_BLOOM_DEFAULT_TAPDB_CONFIG_PATH="$BLOOM_ROOT/config/tapdb-config-${_BLOOM_TAPDB_DATABASE_NAME}.yaml"
+_BLOOM_TAPDB_LOCAL_PG_PORT="$(_bloom_default_tapdb_local_pg_port)"
+_BLOOM_TAPDB_DEV_PORT="${_BLOOM_TAPDB_LOCAL_PG_PORT}"
+_BLOOM_TAPDB_TEST_PORT="${_BLOOM_TAPDB_LOCAL_PG_PORT}"
 _BLOOM_TAPDB_CONFIG_PATH="$(_bloom_prepare_tapdb_config_path "${_BLOOM_TAPDB_CLIENT_ID}" "${_BLOOM_TAPDB_DATABASE_NAME}")"
 export BLOOM_COGNITO_APP_NAME="${BLOOM_COGNITO_APP_NAME:-bloom}"
 export AWS_PROFILE="${AWS_PROFILE:-lsmc}"
@@ -335,8 +334,8 @@ if [[ -n "${_BLOOM_TAPDB_CONFIG_PATH:-}" ]]; then
 else
     echo -e "  ${_YELLOW}⚠${_NC} Bloom TapDB config path is not set"
 fi
-echo -e "  ${_GREEN}✓${_NC} Bloom TapDB dev port=${BLOOM_TAPDB_DEV_PORT}"
-echo -e "  ${_GREEN}✓${_NC} Bloom TapDB test port=${BLOOM_TAPDB_TEST_PORT}"
+echo -e "  ${_GREEN}✓${_NC} Bloom TapDB dev port=${_BLOOM_TAPDB_DEV_PORT}"
+echo -e "  ${_GREEN}✓${_NC} Bloom TapDB test port=${_BLOOM_TAPDB_TEST_PORT}"
 echo -e "  ${_GREEN}✓${_NC} BLOOM_COGNITO_APP_NAME=${BLOOM_COGNITO_APP_NAME}"
 echo -e "  ${_GREEN}✓${_NC} AWS_PROFILE=${AWS_PROFILE}"
 echo -e "  ${_GREEN}✓${_NC} AWS_REGION=${AWS_REGION}"
@@ -350,9 +349,6 @@ deactivate_bloom() {
     unset LSMC_DEPLOYMENT_CODE
     unset MERIDIAN_ENVIRONMENT
     unset MERIDIAN_SANDBOX_PREFIX
-    unset BLOOM_TAPDB_LOCAL_PG_PORT
-    unset BLOOM_TAPDB_DEV_PORT
-    unset BLOOM_TAPDB_TEST_PORT
     unset BLOOM_COGNITO_APP_NAME
     if [[ "${CONDA_DEFAULT_ENV:-}" == "${_BLOOM_CONDA_ENV_NAME}" ]]; then
         conda deactivate 2>/dev/null

--- a/bloom_env.yaml
+++ b/bloom_env.yaml
@@ -40,14 +40,14 @@ dependencies:
   - gunicorn
   - psutil>=5.9.0
   - pip:
-    - cli-core-yo>=0.4.0
-    - daylily-tapdb==3.1.0
+    - cli-core-yo>=0.5.0
+    - daylily-tapdb==3.2.0
     # Optional local editable override for development:
     # - -e ../../daylily/daylily-tapdb
-    - daylily-cognito==0.2.0
+    - daylily-cognito==0.3.0
     # Optional local override for development:
     # - -e ../daylily-cognito
-    - zebra_day==2.4.4
+    - zebra_day==3.2.0
     - daylily-carrier-tracking==0.5.1
     - black
     - uvicorn==0.28.0

--- a/bloom_lims/cli/db.py
+++ b/bloom_lims/cli/db.py
@@ -121,24 +121,18 @@ def _local_pg_port(env_name: str) -> str:
 
 
 def _local_ui_port(env_name: str) -> str:
-    return (
-        os.environ.get("BLOOM_UI_PORT")
-        or str(DEFAULT_BLOOM_WEB_PORT)
-    ).strip()
+    _ = env_name
+    return str(DEFAULT_BLOOM_WEB_PORT).strip()
 
 
 def _tapdb_audit_log_euid_prefix(env_name: str) -> str:
-    return (
-        os.environ.get("BLOOM_TAPDB_AUDIT_LOG_EUID_PREFIX")
-        or _DEFAULT_AUDIT_LOG_EUID_PREFIX
-    ).strip()
+    _ = env_name
+    return _DEFAULT_AUDIT_LOG_EUID_PREFIX
 
 
 def _tapdb_support_email(env_name: str) -> str:
-    return (
-        os.environ.get("BLOOM_UI__SUPPORT_EMAIL")
-        or get_settings().ui.support_email
-    ).strip()
+    _ = env_name
+    return get_settings().ui.support_email.strip()
 
 
 def _update_tapdb_namespace_config(env_name: str) -> None:
@@ -158,16 +152,18 @@ def _update_tapdb_namespace_config(env_name: str) -> None:
 
 def _run_tapdb(args: list[str], check: bool = True) -> int:
     ctx = apply_runtime_environment(get_settings())
+    config_path = str(ctx.config_path or "").strip()
+    if not config_path:
+        raise RuntimeError(
+            "TapDB config path is required. Resolve it via Bloom settings and pass it explicitly "
+            "to TapDB with --config."
+        )
     cmd = _tapdb_base_cmd() + [
-        "--client-id",
-        ctx.client_id,
-        "--database-name",
-        ctx.database_name,
+        "--config",
+        config_path,
         "--env",
         ctx.env,
     ]
-    if ctx.config_path:
-        cmd.extend(["--config", ctx.config_path])
     cmd.extend(args)
     env = _runtime_env()
     result = subprocess.run(cmd, env=env)
@@ -179,19 +175,13 @@ def _run_tapdb(args: list[str], check: bool = True) -> int:
 def _ensure_tapdb_namespace_config(env_name: str) -> None:
     """Initialize TapDB namespaced config so first-run bootstrap works in clean homes."""
     ctx = apply_runtime_environment(get_settings())
-    client_id = ctx.client_id.strip()
-    database_name = ctx.database_name.strip()
-    if not client_id or not database_name:
+    if not str(ctx.config_path or "").strip():
         return
     _ensure_runtime_config_parent()
 
     args = [
         "config",
         "init",
-        "--client-id",
-        client_id,
-        "--database-name",
-        database_name,
         "--env",
         env_name,
     ]
@@ -215,9 +205,7 @@ def _seed_tapdb_templates(
     overwrite: bool = False,
 ) -> None:
     """Seed TAPDB templates (TapDB core config is always included by TapDB)."""
-    tapdb_config_dir = os.environ.get("BLOOM_TAPDB_SEED_CONFIG_PATH", "").strip()
-    if not tapdb_config_dir:
-        tapdb_config_dir = str(_bloom_root() / "config" / "tapdb_templates")
+    tapdb_config_dir = str(_bloom_root() / "config" / "tapdb_templates")
     args = ["db", "data", "seed", env_name]
     if tapdb_config_dir:
         args.extend(["--config", tapdb_config_dir])

--- a/bloom_lims/etc/bloom-config-template.yaml
+++ b/bloom_lims/etc/bloom-config-template.yaml
@@ -8,9 +8,9 @@
 #   2. User config file (~/.config/bloom-<deployment>/bloom-config-<deployment>.yaml)
 #   3. Template defaults (this file)
 #
-# Environment variable format:
-#   - Simple: BLOOM_DEBUG=true
-#   - Nested: BLOOM_TAPDB__ENV=dev
+# Prefer editing the deployment YAML file directly. Environment overrides remain
+# available for non-TapDB settings, but TapDB runtime selection should be driven
+# by the config file plus explicit `--config` / `--env` at the TapDB CLI layer.
 # =============================================================================
 
 # AWS SETTINGS

--- a/bloom_lims/integrations/tapdb_mount.py
+++ b/bloom_lims/integrations/tapdb_mount.py
@@ -13,6 +13,7 @@ from starlette.datastructures import Headers
 from starlette.responses import JSONResponse, RedirectResponse
 
 logger = logging.getLogger(__name__)
+_BLOOM_TAPDB_SCOPE_USER_KEY = "bloom_tapdb_user"
 
 ASGIReceive = Callable[[], Awaitable[dict[str, Any]]]
 ASGISend = Callable[[dict[str, Any]], Awaitable[None]]
@@ -82,6 +83,35 @@ def _is_admin_user(user_data: dict[str, Any]) -> bool:
     return any(str(item).strip().upper() == "ADMIN" for item in roles)
 
 
+def _tapdb_admin_user_from_bloom_user_data(user_data: dict[str, Any]) -> dict[str, Any]:
+    email = str(user_data.get("email") or "").strip().lower()
+    display_name = str(user_data.get("display_name") or user_data.get("name") or email).strip()
+    return {
+        "uid": 0,
+        "username": email,
+        "email": email,
+        "display_name": display_name or email,
+        "role": "admin" if _is_admin_user(user_data) else "user",
+        "is_active": True,
+        "require_password_change": False,
+    }
+
+
+def _configure_embedded_tapdb_auth(admin_main_module: Any, admin_auth_module: Any) -> None:
+    if getattr(admin_main_module, "_bloom_embedded_auth_configured", False):
+        return
+
+    async def _get_current_user(request: Any) -> dict[str, Any] | None:
+        user = request.scope.get(_BLOOM_TAPDB_SCOPE_USER_KEY)
+        if isinstance(user, dict) and str(user.get("email") or "").strip():
+            return user
+        return None
+
+    admin_auth_module.get_current_user = _get_current_user
+    admin_main_module.get_current_user = _get_current_user
+    setattr(admin_main_module, "_bloom_embedded_auth_configured", True)
+
+
 class BloomAdminGuardedASGI:
     """ASGI guard that enforces Bloom admin checks before forwarding."""
 
@@ -121,16 +151,21 @@ class BloomAdminGuardedASGI:
             await response(scope, receive, send)
             return
 
-        await self._inner_app(scope, receive, send)
+        forward_scope = dict(scope)
+        forward_scope[_BLOOM_TAPDB_SCOPE_USER_KEY] = _tapdb_admin_user_from_bloom_user_data(
+            user_data
+        )
+        await self._inner_app(forward_scope, receive, send)
 
 
 def _load_tapdb_admin_app() -> ASGIApp:
-    os.environ["TAPDB_ADMIN_DISABLE_AUTH"] = "1"
     try:
         module = importlib.import_module("admin.main")
+        auth_module = importlib.import_module("admin.auth")
     except Exception as exc:  # pragma: no cover - exercised by startup failure paths
         raise RuntimeError("Failed importing TapDB admin FastAPI app") from exc
 
+    _configure_embedded_tapdb_auth(module, auth_module)
     tapdb_admin_app = getattr(module, "app", None)
     if tapdb_admin_app is None:
         raise RuntimeError("TapDB admin module does not expose FastAPI app")

--- a/bloom_lims/observability_routes.py
+++ b/bloom_lims/observability_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from time import monotonic
 from typing import Annotated
 
@@ -20,6 +21,7 @@ from bloom_lims.tapdb_adapter import BLOOMdb3
 
 
 router = APIRouter(tags=["Health"])
+logger = logging.getLogger(__name__)
 
 
 def _record_auth(request: Request, user: APIUser) -> None:
@@ -91,14 +93,17 @@ async def db_health(
         detail=str(db_component.message or ""),
     )
     if db_component.status != "healthy":
-        bdb, repository = _anomaly_repository(getattr(user, "email", "") or "observability")
         try:
-            repository.record_db_probe_failure(
-                detail=str(db_component.message or ""),
-                latency_ms=float(db_component.latency_ms or ((monotonic() - started) * 1000)),
-            )
-        finally:
-            bdb.close()
+            bdb, repository = _anomaly_repository(getattr(user, "email", "") or "observability")
+            try:
+                repository.record_db_probe_failure(
+                    detail=str(db_component.message or ""),
+                    latency_ms=float(db_component.latency_ms or ((monotonic() - started) * 1000)),
+                )
+            finally:
+                bdb.close()
+        except Exception as exc:
+            logger.warning("Failed to record db probe anomaly: %s", exc)
     projection, payload = request.app.state.observability.db_health()
     if not payload.get("observed_at"):
         payload["observed_at"] = details.get("observed_at")

--- a/bloom_lims/schema_drift.py
+++ b/bloom_lims/schema_drift.py
@@ -46,15 +46,12 @@ def _tapdb_cmd(args: list[str]) -> subprocess.CompletedProcess[str]:
         sys.executable,
         "-m",
         "daylily_tapdb.cli",
-        "--client-id",
-        env.client_id,
-        "--database-name",
-        env.database_name,
         "--env",
         env.env,
     ]
-    if env.config_path:
-        cmd.extend(["--config", env.config_path])
+    if not str(env.config_path or "").strip():
+        raise RuntimeError("TapDB schema drift checks require an explicit config path.")
+    cmd.extend(["--config", env.config_path])
     cmd.extend(args)
     return subprocess.run(
         cmd,

--- a/bloom_lims/tapdb_metrics.py
+++ b/bloom_lims/tapdb_metrics.py
@@ -4,18 +4,13 @@ This module is adapted from the TapDB GUI implementation so Bloom can:
 1) collect per-query latency metrics via SQLAlchemy Engine events
 2) render the same metrics context as TapDB's `/admin/metrics`
 
-Configuration (same semantics as TapDB GUI):
-- `TAPDB_DB_METRICS=1|0` to force enable/disable.
-  - Default: enabled for non-pytest runs, disabled under pytest.
-- `TAPDB_DB_METRICS_DIR` to override root metrics directory.
-
-Metrics are best-effort and may be dropped under load to avoid impacting
-request latency.
+Metrics settings come from the explicit TapDB config selected by Bloom's
+service config. Metrics are best-effort and may be dropped under load to
+avoid impacting request latency.
 """
 
 from __future__ import annotations
 
-import os
 import queue
 import re
 import sys
@@ -30,11 +25,8 @@ from typing import Iterable, Optional
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 
-try:
-    # TapDB v2 config resolver (optional; we fall back if unavailable/misconfigured).
-    from daylily_tapdb.cli.context import resolve_context
-except Exception:  # pragma: no cover
-    resolve_context = None
+from bloom_lims.config import apply_runtime_environment, get_settings
+from daylily_tapdb.cli.db_config import get_admin_settings_for_env
 
 
 request_path_var: ContextVar[str] = ContextVar("tapdb_request_path", default="")
@@ -66,31 +58,27 @@ def _parse_bool(value: object, *, default: bool) -> bool:
     return default
 
 
-def _env_int(name: str, default: int) -> int:
-    raw = (os.environ.get(name) or "").strip()
-    if not raw:
-        return default
-    try:
-        return int(raw)
-    except ValueError:
-        return default
+def _resolved_bloom_runtime(env_name: str | None = None) -> tuple[str, Path, dict[str, object]]:
+    ctx = apply_runtime_environment(get_settings())
+    resolved_env = str(env_name or ctx.env).strip().lower() or ctx.env
+    config_path = Path(ctx.config_path).expanduser().resolve()
+    admin_settings = get_admin_settings_for_env(
+        resolved_env,
+        config_path=config_path,
+        client_id=ctx.client_id,
+        database_name=ctx.database_name,
+        allow_namespace_fallback=False,
+    )
+    return resolved_env, config_path, admin_settings
 
 
-def _env_float(name: str, default: float) -> float:
-    raw = (os.environ.get(name) or "").strip()
-    if not raw:
-        return default
-    try:
-        return float(raw)
-    except ValueError:
-        return default
-
-
-def metrics_enabled() -> bool:
-    # Mirror TapDB GUI: default enabled for real runs, disabled under pytest unless forced.
+def metrics_enabled(env_name: str | None = None) -> bool:
+    enabled = _resolved_bloom_runtime(env_name)[2].get("metrics_enabled")
+    if isinstance(enabled, bool):
+        return enabled
     if "pytest" in sys.modules:
-        return _parse_bool(os.environ.get("TAPDB_DB_METRICS"), default=False)
-    return _parse_bool(os.environ.get("TAPDB_DB_METRICS"), default=True)
+        return False
+    return True
 
 
 def _sanitize_tsv(value: object) -> str:
@@ -134,23 +122,8 @@ def _extract_table_hint(statement: str, op: str) -> str:
 
 
 def _metrics_root_dir(env_name: str) -> Path:
-    env = (env_name or "dev").strip().lower()
-    override = (os.environ.get("TAPDB_DB_METRICS_DIR") or "").strip()
-    if override:
-        return Path(override).expanduser() / env
-
-    if resolve_context is not None:
-        try:
-            ctx = resolve_context(require_keys=False, env_name=env)
-        except Exception:
-            ctx = None
-        if ctx is not None:
-            try:
-                return ctx.runtime_dir(env) / "metrics"
-            except Exception:
-                pass
-
-    return Path.home() / ".config" / "tapdb" / "_legacy" / env / "metrics"
+    resolved_env, config_path, _admin_settings = _resolved_bloom_runtime(env_name)
+    return config_path.parent / resolved_env / "metrics"
 
 
 def two_week_period_start_utc(now_utc: datetime) -> datetime:
@@ -208,8 +181,9 @@ class MetricsRow:
 class TSVMetricsWriter:
     def __init__(self, env_name: str):
         self._env_name = (env_name or "dev").strip().lower()
-        self._queue_max = _env_int("TAPDB_DB_METRICS_QUEUE_MAX", 20000)
-        self._flush_secs = _env_float("TAPDB_DB_METRICS_FLUSH_SECS", 1.0)
+        admin_settings = _resolved_bloom_runtime(self._env_name)[2]
+        self._queue_max = int(admin_settings.get("metrics_queue_max", 20000))
+        self._flush_secs = float(admin_settings.get("metrics_flush_seconds", 1.0))
         self._queue: queue.Queue[str] = queue.Queue(maxsize=self._queue_max)
         self._dropped = 0
         self._dropped_lock = threading.Lock()
@@ -538,4 +512,3 @@ def build_metrics_page_context(env_name: str, *, limit: int = 5000) -> dict:
         "dropped_count": dropped,
         "summary": summary,
     }
-

--- a/config/bloom-config-template.yaml
+++ b/config/bloom-config-template.yaml
@@ -8,9 +8,9 @@
 #   2. User config file (~/.config/bloom-<deployment>/bloom-config-<deployment>.yaml)
 #   3. Template defaults (this file)
 #
-# Environment variable format:
-#   - Simple: BLOOM_DEBUG=true
-#   - Nested: BLOOM_TAPDB__ENV=dev
+# Prefer editing the deployment YAML file directly. Environment overrides remain
+# available for non-TapDB settings, but TapDB runtime selection should be driven
+# by the config file plus explicit `--config` / `--env` at the TapDB CLI layer.
 # =============================================================================
 
 # AWS SETTINGS
@@ -35,10 +35,10 @@ ui:
 # -----------------------------------------------------------------------------
 tapdb:
   env: "dev"                    # dev, test, prod
-  client_id: "bloom"            # TAPDB_CLIENT_ID namespace key
-  database_name: "bloom"        # TAPDB_DATABASE_NAME namespace key
-  strict_namespace: true        # TAPDB_STRICT_NAMESPACE (requires TapDB v2 namespaced config)
-  config_path: ""               # Optional TAPDB_CONFIG_PATH override
+  client_id: "bloom"            # TapDB client namespace key stored in config
+  database_name: "bloom"        # TapDB database namespace stored in config
+  strict_namespace: true        # Require namespaced TapDB config semantics
+  config_path: ""               # Optional explicit TapDB config path
   local_pg_port: __BLOOM_TAPDB_LOCAL_PG_PORT__           # Default local TapDB PostgreSQL port for dev/test
   min_version: "3.0.6"         # Required minimum daylily-tapdb version
   max_version_exclusive: "4.0.0"

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -14,25 +14,23 @@ Bloom authentication is Cognito-backed and should be managed through `daycog` fo
 export AWS_PROFILE=lsmc
 export AWS_REGION=us-west-2
 export AWS_DEFAULT_REGION=us-west-2
-export TAPDB_ENV=dev
-export TAPDB_DATABASE_NAME=bloom
 ```
 
 ## Configure Cognito (via TapDB)
 
 ```bash
 # Show current TapDB context
-python -m daylily_tapdb.cli info
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev info
 
 # Initialize the TapDB namespace config for Bloom
-python -m daylily_tapdb.cli --client-id bloom --database-name bloom config init \
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev config init \
   --env dev --db-port dev=5566 --ui-port dev=8912
 
 # Update shared Cognito app/pool state through daycog
 daycog config create-all --pool-name daylily-ursa-users --region us-west-2 --default-client atlas
 
 # Bind the Bloom namespace to the shared Cognito app client
-python -m daylily_tapdb.cli --client-id bloom --database-name bloom config update \
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev config update \
   --env dev \
   --cognito-user-pool-id us-west-2_5r8gIqV5P \
   --cognito-app-client-id 6j2pa8nr9ve19aeuhnb1ocpl2r \
@@ -66,7 +64,9 @@ auth:
 
 tapdb:
   env: dev
+  client_id: bloom
   database_name: bloom
+  config_path: ~/.config/tapdb/bloom/bloom/tapdb-config.yaml
 ```
 
 ## Start Bloom

--- a/docs/AUTH_INTEGRATION.md
+++ b/docs/AUTH_INTEGRATION.md
@@ -45,8 +45,8 @@ Auth behavior for mounted path:
 - API/XHR-style denied access -> JSON `401`/`403`
 
 TapDB-local auth in mounted mode:
-- Bloom sets `TAPDB_ADMIN_DISABLE_AUTH=1` before loading TapDB admin app
-- TapDB login flow is bypassed for mounted requests
+- Bloom injects an explicit mounted-user identity into the embedded TapDB app
+- TapDB login flow is bypassed for mounted requests without mutating `TAPDB_ADMIN_*`
 - standalone TapDB usage remains unchanged outside Bloom
 
 ## API Tokens

--- a/docs/TAPDB_CLI_SPECIFICATION.md
+++ b/docs/TAPDB_CLI_SPECIFICATION.md
@@ -5,15 +5,13 @@ This document defines the TapDB command surface Bloom relies on.
 ## Required Context
 
 ```bash
-export TAPDB_ENV=dev
-export TAPDB_DATABASE_NAME=bloom
 export AWS_PROFILE=lsmc
 export AWS_REGION=us-west-2
 export AWS_DEFAULT_REGION=us-west-2
 ```
 
 For namespace isolation with multiple apps under one user, prefer:
-- `~/.config/tapdb/tapdb-config-bloom.yaml`
+- `~/.config/tapdb/bloom/bloom/tapdb-config.yaml`
 
 ## Activation
 
@@ -25,44 +23,44 @@ source ../../daylily-tapdb/activate
 
 ```bash
 # local postgres runtime + schema + seed path
-python -m daylily_tapdb.cli bootstrap local --no-gui
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev bootstrap local --no-gui
 
 # aurora bootstrap path
-python -m daylily_tapdb.cli bootstrap aurora --cluster <cluster-id> --region us-west-2 --no-gui
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env prod bootstrap aurora --cluster <cluster-id> --region us-west-2 --no-gui
 ```
 
 ## PostgreSQL Runtime (`tapdb pg`)
 
 ```bash
-python -m daylily_tapdb.cli pg init dev
-python -m daylily_tapdb.cli pg start-local dev
-python -m daylily_tapdb.cli pg stop-local dev
-python -m daylily_tapdb.cli pg status
-python -m daylily_tapdb.cli pg logs
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev pg init dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev pg start-local dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev pg stop-local dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev pg status
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev pg logs
 ```
 
 ## Database/Schema/Data (`tapdb db`)
 
 ```bash
-python -m daylily_tapdb.cli db create dev
-python -m daylily_tapdb.cli db setup dev
-python -m daylily_tapdb.cli db schema status dev
-python -m daylily_tapdb.cli db schema migrate dev
-python -m daylily_tapdb.cli db schema reset dev --force
-python -m daylily_tapdb.cli db data seed dev
-python -m daylily_tapdb.cli db data backup dev
-python -m daylily_tapdb.cli db data restore dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev db create dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev db setup dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev db schema status dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev db schema migrate dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev db schema reset dev --force
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev db data seed dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev db data backup dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev db data restore dev
 ```
 
 ## Config and Cognito Ownership
 
 ```bash
-python -m daylily_tapdb.cli --client-id bloom --database-name bloom config init \
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev config init \
   --env dev --db-port dev=5566 --ui-port dev=8912
-python -m daylily_tapdb.cli --client-id bloom --database-name bloom config update \
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev config update \
   --env dev --audit-log-euid-prefix audit.bloom --support-email support@daylilyinformatics.com
 daycog config create-all --pool-name daylily-ursa-users --region us-west-2 --default-client atlas
-python -m daylily_tapdb.cli --client-id bloom --database-name bloom config update \
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev config update \
   --env dev \
   --cognito-user-pool-id us-west-2_5r8gIqV5P \
   --cognito-app-client-id 6j2pa8nr9ve19aeuhnb1ocpl2r \

--- a/docs/TAPDB_SPECIFICATION.md
+++ b/docs/TAPDB_SPECIFICATION.md
@@ -1284,14 +1284,11 @@ class TAPDBConnection:
         Initialize database connection.
 
         Args:
-            connection_string: PostgreSQL connection string.
-                              Falls back to TAPDB_DATABASE_URL env var.
+            connection_string: PostgreSQL connection string provided explicitly
+                              by the caller or resolved from TapDB config.
             echo: Enable SQLAlchemy query logging.
         """
-        self.connection_string = connection_string or os.environ.get(
-            'TAPDB_DATABASE_URL',
-            'postgresql://localhost/tapdb'
-        )
+        self.connection_string = connection_string or 'postgresql://localhost/tapdb'
         self.engine = create_engine(self.connection_string, echo=echo)
         self.SessionLocal = sessionmaker(bind=self.engine)
         self._session: Optional[Session] = None
@@ -2468,8 +2465,8 @@ CREATE SEQUENCE xx_instance_seq;           -- XX (action)
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `TAPDB_DATABASE_URL` | PostgreSQL connection string | `postgresql://localhost/tapdb` |
-| `TAPDB_CONFIG_PATH` | Path to template configuration | `./config` |
+| Explicit DB URL argument | PostgreSQL connection string | `postgresql://localhost/tapdb` |
+| Explicit config path | Path to template configuration | `./config` |
 | `TAPDB_ECHO_SQL` | Enable SQL query logging | `false` |
 | `TAPDB_POOL_SIZE` | Connection pool size | `5` |
 | `TAPDB_MAX_OVERFLOW` | Max overflow connections | `10` |
@@ -2484,8 +2481,8 @@ from daylily_tapdb import TAPDBConnection, TemplateManager, InstanceFactory
 from daylily_tapdb.models import generic_instance, container_instance
 
 # Initialize
-db = TAPDBConnection(os.environ['DATABASE_URL'])
-templates = TemplateManager(db, Path('./config'))
+db = TAPDBConnection("postgresql://localhost/tapdb")
+templates = TemplateManager(db, Path("./config"))
 factory = InstanceFactory(db, templates)
 
 # Create objects
@@ -2691,11 +2688,9 @@ from daylily_tapdb import TAPDBConnection
 @pytest.fixture(scope="session")
 def db_connection():
     """Provide database connection for integration tests."""
-    db_url = os.environ.get(
-        'TAPDB_TEST_DATABASE_URL',
+    conn = TAPDBConnection(
         'postgresql://tapdb:tapdb_test_password@localhost:5432/tapdb_test'
     )
-    conn = TAPDBConnection(db_url)
 
     # Apply schema (including triggers)
     conn.apply_schema()

--- a/docs/backup_recovery.md
+++ b/docs/backup_recovery.md
@@ -14,13 +14,11 @@ Bloom no longer implements an in-repo backup subsystem.
 export AWS_PROFILE=lsmc
 export AWS_REGION=us-west-2
 export AWS_DEFAULT_REGION=us-west-2
-export TAPDB_ENV=dev
-export TAPDB_DATABASE_NAME=bloom
 ```
 
 ## Examples
 
 ```bash
-python -m daylily_tapdb.cli db data backup dev
-python -m daylily_tapdb.cli db data restore dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev db data backup dev
+python -m daylily_tapdb.cli --config ~/.config/tapdb/bloom/bloom/tapdb-config.yaml --env dev db data restore dev
 ```

--- a/docs/tapdb_mount_completion_report.md
+++ b/docs/tapdb_mount_completion_report.md
@@ -17,8 +17,8 @@
 
 ## How TapDB-Local Auth Is Bypassed
 
-- Bloom sets `TAPDB_ADMIN_DISABLE_AUTH=1` before importing `admin.main.app`.
-- This disables TapDB-local auth flow for mounted mode in the Bloom process.
+- Bloom wires an explicit mounted-user resolver into the embedded TapDB app.
+- This bypasses TapDB-local auth flow for mounted mode without injecting `TAPDB_ADMIN_*`.
 - Result: Bloom auth/session is the sole gate for mounted TapDB access.
 
 ## Remaining Caveats
@@ -26,4 +26,3 @@
 - If mount is enabled and TapDB admin app fails to import/initialize, Bloom startup fails fast.
 - Mounted mode assumes Bloom session middleware is active for mounted requests.
 - Standalone TapDB behavior is unchanged when run outside Bloom.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.12"
 dependencies = [
-    "cli-core-yo>=0.4.0",
-    "daylily-tapdb==3.1.0",
-    "daylily-cognito==0.2.0",
+    "cli-core-yo>=0.5.0",
+    "daylily-tapdb==3.2.0",
+    "daylily-cognito==0.3.0",
     "fastapi>=0.110.0",
     "httpx>=0.27.2",
     "itsdangerous>=2.1.2",
@@ -41,7 +41,7 @@ dependencies = [
     "sqlalchemy>=2.0.23",
     "starlette>=0.35.1",
     "uvicorn>=0.28.0",
-    "zebra-day==3.0.0",
+    "zebra-day==3.2.0",
     "daylily-carrier-tracking==0.5.1",
 ]
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytest
 ipython
 psycopg2
 jinja2~=3.1.2
-zebra_day==3.0.0
+zebra_day==3.2.0
 fedex_tracking_day==0.2.8
 setuptools~=51.1.0
 SQLAlchemy~=2.0.19

--- a/tests/support/runtime.py
+++ b/tests/support/runtime.py
@@ -56,7 +56,7 @@ def create_temp_tapdb_config(
         "\n".join(
             [
                 "meta:",
-                "  config_version: 2",
+                "  config_version: 3",
                 "  client_id: bloom",
                 "  database_name: bloom",
                 "  euid_client_code: B",

--- a/tests/test_cli_db_command_paths.py
+++ b/tests/test_cli_db_command_paths.py
@@ -30,6 +30,14 @@ def test_run_tapdb_raises_for_nonzero_check(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(db_commands, "_tapdb_base_cmd", lambda: ["tapdb"])
     monkeypatch.setattr(db_commands, "_runtime_env", lambda: {})
     monkeypatch.setattr(
+        db_commands,
+        "apply_runtime_environment",
+        lambda _settings: SimpleNamespace(
+            config_path="/tmp/bloom-tapdb.yaml",
+            env="dev",
+        ),
+    )
+    monkeypatch.setattr(
         db_commands.subprocess,
         "run",
         lambda *_args, **_kwargs: SimpleNamespace(returncode=7),
@@ -44,6 +52,14 @@ def test_run_tapdb_raises_for_nonzero_check(monkeypatch: pytest.MonkeyPatch) -> 
 def test_run_tapdb_returns_nonzero_when_check_false(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(db_commands, "_tapdb_base_cmd", lambda: ["tapdb"])
     monkeypatch.setattr(db_commands, "_runtime_env", lambda: {})
+    monkeypatch.setattr(
+        db_commands,
+        "apply_runtime_environment",
+        lambda _settings: SimpleNamespace(
+            config_path="/tmp/bloom-tapdb.yaml",
+            env="dev",
+        ),
+    )
     monkeypatch.setattr(
         db_commands.subprocess,
         "run",
@@ -115,10 +131,6 @@ def test_ensure_tapdb_namespace_config_initializes_then_updates(
             [
                 "config",
                 "init",
-                "--client-id",
-                "bloom",
-                "--database-name",
-                "bloom",
                 "--env",
                 "dev",
                 "--db-port",

--- a/tests/test_observability_contract.py
+++ b/tests/test_observability_contract.py
@@ -177,6 +177,35 @@ def test_db_health_exposes_last_known_schema_drift(monkeypatch) -> None:
     assert schema_drift["tool_version"] == "3.0.9"
 
 
+def test_db_health_returns_payload_when_anomaly_recording_fails(monkeypatch) -> None:
+    async def _fake_check_database_health():
+        return SimpleNamespace(
+            status="unhealthy",
+            latency_ms=7.5,
+            message="db down",
+            details={"observed_at": "2026-03-29T12:02:00+00:00"},
+        )
+
+    monkeypatch.setattr(
+        "bloom_lims.observability_routes.check_database_health",
+        _fake_check_database_health,
+    )
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("cannot connect to anomaly store")
+
+    monkeypatch.setattr("bloom_lims.observability_routes._anomaly_repository", _boom)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/db_health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["database"]["status"] == "error"
+    assert payload["database"]["latest"]["detail"] == "db down"
+    assert payload["database"]["observed_at"]
+
+
 def test_observability_helpers_cover_empty_rollups_and_db_fallback(monkeypatch) -> None:
     assert _percentile([], 0.95) == 0.0
 


### PR DESCRIPTION
## What changed
- remove ambient TapDB runtime config dependence from Bloom
- update Bloom to the new shared-library versions, including zebra-day 3.2.0
- make /db_health degrade cleanly when anomaly recording cannot reach the DB

## Why
- align Bloom with the explicit TapDB config contract
- keep observability endpoints stable during DB outages
- consume the new shared-library release train

## Validation
- skipped in this publish run per release request