### PR TITLE
[codex] move Bloom to zebra_day 4.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "sqlalchemy>=2.0.23",
     "starlette>=0.35.1",
     "uvicorn>=0.28.0",
-    "zebra-day==3.5.2",
+    "zebra-day==4.0.0",
     "daylily-carrier-tracking==0.5.1",
 ]
 classifiers = [


### PR DESCRIPTION
## Summary
- bump the zebra_day dependency to 4.0.0
- validate Bloom's zebra_day integration tests against the released 4.0.0 package

## Testing
- source ./activate local-q
- python -m pip install -e ".[dev]"
- pytest --no-cov -q tests/test_zebra_day_integration.py