### PR TITLE
[codex] Adopt cli-core-yo v2 command policies in Bloom CLI

### DIFF
--- a/bloom_lims/cli/__init__.py
+++ b/bloom_lims/cli/__init__.py
@@ -8,7 +8,14 @@ from pathlib import Path
 
 from cli_core_yo.app import create_app as _create_app
 from cli_core_yo.app import run
-from cli_core_yo.spec import CliSpec, ConfigSpec, EnvSpec, PluginSpec, PolicySpec, XdgSpec
+from cli_core_yo.spec import (
+    CliSpec,
+    ConfigSpec,
+    EnvSpec,
+    PluginSpec,
+    PolicySpec,
+    XdgSpec,
+)
 
 from bloom_lims.config import (
     _resolve_deployment_code,

--- a/bloom_lims/cli/__init__.py
+++ b/bloom_lims/cli/__init__.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from cli_core_yo.app import create_app as _create_app
 from cli_core_yo.app import run
-from cli_core_yo.spec import CliSpec, ConfigSpec, EnvSpec, PluginSpec, XdgSpec
+from cli_core_yo.spec import CliSpec, ConfigSpec, EnvSpec, PluginSpec, PolicySpec, XdgSpec
 
 from bloom_lims.config import (
     _resolve_deployment_code,
@@ -76,6 +76,7 @@ spec = CliSpec(
     xdg=XdgSpec(
         app_dir_name=f"bloom-{_resolve_deployment_code()}",
     ),
+    policy=PolicySpec(),
     config=ConfigSpec(
         xdg_relative_path=f"bloom-config-{_resolve_deployment_code()}.yaml",
         template_bytes=build_default_config_template(),

--- a/bloom_lims/cli/_registry_v2.py
+++ b/bloom_lims/cli/_registry_v2.py
@@ -1,0 +1,59 @@
+"""Explicit cli-core-yo v2 registration helpers for Bloom."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from cli_core_yo.registry import CommandRegistry
+from cli_core_yo.spec import CommandPolicy
+
+EXEMPT = CommandPolicy(runtime_guard="exempt")
+EXEMPT_INTERACTIVE = CommandPolicy(interactive=True, runtime_guard="exempt")
+EXEMPT_LONG_RUNNING = CommandPolicy(long_running=True, runtime_guard="exempt")
+EXEMPT_MUTATING = CommandPolicy(mutates_state=True, runtime_guard="exempt")
+EXEMPT_MUTATING_INTERACTIVE = CommandPolicy(
+    mutates_state=True,
+    interactive=True,
+    runtime_guard="exempt",
+)
+EXEMPT_MUTATING_LONG_RUNNING = CommandPolicy(
+    mutates_state=True,
+    long_running=True,
+    runtime_guard="exempt",
+)
+
+CommandDef = tuple[str, Callable[..., Any], CommandPolicy]
+
+
+def help_text(callback: Callable[..., Any]) -> str:
+    """Return deterministic CLI help text from the callback docstring."""
+    return inspect.getdoc(callback) or ""
+
+
+def register_group_commands(
+    registry: CommandRegistry,
+    group_path: str,
+    group_help: str,
+    commands: Sequence[CommandDef],
+) -> None:
+    """Register one explicit command group and its command callbacks."""
+    if "/" in group_path:
+        parent = registry._resolve_parent(group_path)  # type: ignore[attr-defined]
+        if parent is None:
+            raise ValueError(f"Unable to create command group {group_path!r}")
+        if group_help and parent.help_text and parent.help_text != group_help:
+            raise ValueError(f"Conflicting help text for command group {group_path!r}")
+        if group_help and not parent.help_text:
+            parent.help_text = group_help
+    else:
+        registry.add_group(group_path, help_text=group_help)
+    for name, callback, policy in commands:
+        registry.add_command(
+            group_path,
+            name,
+            callback,
+            help_text=help_text(callback),
+            policy=policy,
+        )

--- a/bloom_lims/cli/config_extra.py
+++ b/bloom_lims/cli/config_extra.py
@@ -13,6 +13,7 @@ from rich.table import Table
 if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
+from cli_core_yo.spec import CommandPolicy
 
 from bloom_lims.config import (
     apply_runtime_environment,
@@ -32,6 +33,7 @@ from bloom_lims.schema_drift import (
 
 console = Console()
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+REQUIRED_POLICY = CommandPolicy(runtime_guard="required")
 
 
 def _tapdb_schema_drift_check(env_name: str) -> tuple[int, dict[str, object], str]:
@@ -232,14 +234,23 @@ def _doctor() -> None:
 def register(registry: CommandRegistry, spec: CliSpec) -> None:
     """cli-core-yo plugin: register extra config subcommands."""
     registry.add_command(
-        "config", "shell", _shell, "Open interactive Python shell with BLOOM loaded"
+        "config",
+        "shell",
+        _shell,
+        help_text="Open interactive Python shell with BLOOM loaded",
+        policy=REQUIRED_POLICY,
     )
     registry.add_command(
         "config",
         "doctor",
         _doctor,
-        "Verify environment, dependencies, and configuration",
+        help_text="Verify environment, dependencies, and configuration",
+        policy=REQUIRED_POLICY,
     )
     registry.add_command(
-        "config", "status", _status, "Show environment and configuration status"
+        "config",
+        "status",
+        _status,
+        help_text="Show environment and configuration status",
+        policy=REQUIRED_POLICY,
     )

--- a/bloom_lims/cli/config_extra.py
+++ b/bloom_lims/cli/config_extra.py
@@ -7,13 +7,13 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from cli_core_yo.spec import CommandPolicy
 from rich.console import Console
 from rich.table import Table
 
 if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
-from cli_core_yo.spec import CommandPolicy
 
 from bloom_lims.config import (
     apply_runtime_environment,

--- a/bloom_lims/cli/db.py
+++ b/bloom_lims/cli/db.py
@@ -18,6 +18,11 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from bloom_lims.cli._registry_v2 import (
+    EXEMPT_MUTATING,
+    EXEMPT_MUTATING_INTERACTIVE,
+    register_group_commands,
+)
 from bloom_lims.config import (
     DEFAULT_BLOOM_TAPDB_LOCAL_PG_PORT,
     DEFAULT_BLOOM_WEB_PORT,
@@ -323,4 +328,15 @@ def db_nuke(
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:
     """cli-core-yo plugin: register the db command group."""
-    registry.add_typer_app(None, db_app, "db", "Database management commands.")
+    _ = spec
+    register_group_commands(
+        registry,
+        "db",
+        "Database management commands.",
+        [
+            ("build", db_build, EXEMPT_MUTATING),
+            ("seed", db_seed, EXEMPT_MUTATING),
+            ("reset", db_reset, EXEMPT_MUTATING_INTERACTIVE),
+            ("nuke", db_nuke, EXEMPT_MUTATING_INTERACTIVE),
+        ],
+    )

--- a/bloom_lims/cli/integrations.py
+++ b/bloom_lims/cli/integrations.py
@@ -12,6 +12,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from bloom_lims.cli._registry_v2 import EXEMPT, register_group_commands
 from bloom_lims.config import get_settings
 
 integrations_app = typer.Typer(
@@ -62,6 +63,14 @@ integrations_app.add_typer(atlas_app, name="atlas")
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:
     """cli-core-yo plugin: register the integrations command group."""
-    registry.add_typer_app(
-        None, integrations_app, "integrations", "External integration commands."
+    _ = spec
+    registry.add_group("integrations", help_text="External integration commands.")
+    register_group_commands(
+        registry,
+        "integrations/atlas",
+        "Atlas integration configuration and diagnostics.",
+        [
+            ("show", show_atlas_config, EXEMPT),
+            ("doctor", doctor_atlas_integration, EXEMPT),
+        ],
     )

--- a/bloom_lims/cli/quality.py
+++ b/bloom_lims/cli/quality.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import typer
 
+from bloom_lims.cli._registry_v2 import EXEMPT_LONG_RUNNING, register_group_commands
+
 quality_app = typer.Typer(
     help="Code-quality and validation commands", no_args_is_help=True
 )
@@ -66,4 +68,14 @@ def bandit(ctx: typer.Context) -> None:
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:
     """cli-core-yo plugin: register the quality command group."""
-    registry.add_typer_app(None, quality_app, "quality", "Code-quality commands.")
+    _ = spec
+    register_group_commands(
+        registry,
+        "quality",
+        "Code-quality commands.",
+        [
+            ("check", check, EXEMPT_LONG_RUNNING),
+            ("ruff", ruff, EXEMPT_LONG_RUNNING),
+            ("bandit", bandit, EXEMPT_LONG_RUNNING),
+        ],
+    )

--- a/bloom_lims/cli/server.py
+++ b/bloom_lims/cli/server.py
@@ -28,6 +28,13 @@ from cli_core_yo.server import (
 )
 from rich.console import Console
 
+from bloom_lims.cli._registry_v2 import (
+    EXEMPT,
+    EXEMPT_LONG_RUNNING,
+    EXEMPT_MUTATING,
+    EXEMPT_MUTATING_LONG_RUNNING,
+    register_group_commands,
+)
 from bloom_lims.config import (
     DEFAULT_BLOOM_WEB_PORT,
     apply_runtime_environment,
@@ -366,4 +373,15 @@ def logs(
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:
     """cli-core-yo plugin: register the server command group."""
-    registry.add_typer_app(None, server_app, "server", "Server lifecycle commands.")
+    _ = spec
+    register_group_commands(
+        registry,
+        "server",
+        "Server lifecycle commands.",
+        [
+            ("start", start, EXEMPT_MUTATING_LONG_RUNNING),
+            ("stop", stop, EXEMPT_MUTATING),
+            ("status", status, EXEMPT),
+            ("logs", logs, EXEMPT_LONG_RUNNING),
+        ],
+    )

--- a/bloom_lims/cli/server.py
+++ b/bloom_lims/cli/server.py
@@ -177,7 +177,9 @@ def start(
     host, port = _runtime_host_and_port(port, host)
     shown_host = display_host(host)
     if not ssl and (cert or key):
-        console.print("[red]✗[/red] --cert and --key require HTTPS; omit them with --no-ssl")
+        console.print(
+            "[red]✗[/red] --cert and --key require HTTPS; omit them with --no-ssl"
+        )
         raise typer.Exit(1)
 
     protocol = "https" if ssl else "http"

--- a/bloom_lims/cli/test.py
+++ b/bloom_lims/cli/test.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import typer
 
+from bloom_lims.cli._registry_v2 import EXEMPT_LONG_RUNNING, register_group_commands
+
 test_app = typer.Typer(help="Test execution commands", no_args_is_help=True)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -37,4 +39,12 @@ def run(ctx: typer.Context) -> None:
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:
     """cli-core-yo plugin: register the test command group."""
-    registry.add_typer_app(None, test_app, "test", "Test execution commands.")
+    _ = spec
+    register_group_commands(
+        registry,
+        "test",
+        "Test execution commands.",
+        [
+            ("run", run, EXEMPT_LONG_RUNNING),
+        ],
+    )

--- a/bloom_lims/cli/users.py
+++ b/bloom_lims/cli/users.py
@@ -23,9 +23,7 @@ from bloom_lims.auth.services.user_api_tokens import (
 from bloom_lims.cli._registry_v2 import EXEMPT_MUTATING, register_group_commands
 from bloom_lims.db import BLOOMdb3
 
-users_app = typer.Typer(
-    help="Bloom-specific user commands.", no_args_is_help=True
-)
+users_app = typer.Typer(help="Bloom-specific user commands.", no_args_is_help=True)
 
 
 class TokenScope(str, Enum):

--- a/bloom_lims/cli/users.py
+++ b/bloom_lims/cli/users.py
@@ -15,12 +15,12 @@ if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
 
-from bloom_lims.cli._registry_v2 import EXEMPT_MUTATING, register_group_commands
 from bloom_lims.auth.rbac import API_ACCESS_GROUP, Role
 from bloom_lims.auth.services.user_api_tokens import (
     TokenCreateInput,
     UserAPITokenService,
 )
+from bloom_lims.cli._registry_v2 import EXEMPT_MUTATING, register_group_commands
 from bloom_lims.db import BLOOMdb3
 
 users_app = typer.Typer(

--- a/bloom_lims/cli/users.py
+++ b/bloom_lims/cli/users.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 import typer
 from daylily_tapdb.user_store import get_by_login_or_email
 
+from bloom_lims.cli._registry_v2 import EXEMPT_MUTATING, register_group_commands
 from bloom_lims.auth.rbac import API_ACCESS_GROUP, Role
 from bloom_lims.auth.services.user_api_tokens import (
     TokenCreateInput,
@@ -85,4 +86,12 @@ def issue_token(
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:
     """cli-core-yo plugin: register the users command group."""
-    registry.add_typer_app(None, users_app, "users", "User management commands.")
+    _ = spec
+    register_group_commands(
+        registry,
+        "users",
+        "User management commands.",
+        [
+            ("issue-token", issue_token, EXEMPT_MUTATING),
+        ],
+    )

--- a/bloom_lims/cli/users.py
+++ b/bloom_lims/cli/users.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING
 
+import typer
+from daylily_tapdb.user_store import get_by_login_or_email
+
 if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
-
-import typer
-from daylily_tapdb.user_store import get_by_login_or_email
 
 from bloom_lims.cli._registry_v2 import EXEMPT_MUTATING, register_group_commands
 from bloom_lims.auth.rbac import API_ACCESS_GROUP, Role


### PR DESCRIPTION
## Summary
- port the Bloom CLI registry updates onto fresh `main`
- add the shared `_registry_v2` helper and command policy wiring
- replace stale PR #230 with a fresh branch on the current release line

## Validation
- `python -m py_compile bloom_lims/cli/__init__.py bloom_lims/cli/_registry_v2.py bloom_lims/cli/config_extra.py bloom_lims/cli/db.py bloom_lims/cli/integrations.py bloom_lims/cli/quality.py bloom_lims/cli/server.py bloom_lims/cli/test.py bloom_lims/cli/users.py`