### PR TITLE
Fix external broker session hostname

### DIFF
--- a/bloom_lims/gui/web_session.py
+++ b/bloom_lims/gui/web_session.py
@@ -41,7 +41,10 @@ def build_bloom_web_session_config(
             )
         public_base_url = _origin(broker.callback_url)
         return CognitoWebSessionConfig(
-            domain=urlparse(broker.login_url).netloc,
+            domain=_required_url_hostname(
+                broker.login_url,
+                field_name="auth.external_broker.login_url",
+            ),
             client_id=broker.service_id,
             redirect_uri=broker.callback_url,
             logout_uri=broker.logout_url,
@@ -79,6 +82,13 @@ def build_bloom_web_session_config(
         allow_insecure_http=public_base_url.startswith("http://"),
         server_instance_id=get_server_instance_id(),
     )
+
+
+def _required_url_hostname(value: str, *, field_name: str) -> str:
+    parsed = urlparse(str(value or "").strip())
+    if not parsed.scheme or not parsed.netloc or not parsed.hostname:
+        raise RuntimeError(f"Bloom {field_name} must be an absolute URL with host")
+    return parsed.hostname
 
 
 def _session_secret(auth_settings: Any) -> str:

--- a/tests/test_gui_auth_callback.py
+++ b/tests/test_gui_auth_callback.py
@@ -158,10 +158,10 @@ def _external_broker_settings() -> BloomSettings:
             "jwt_secret": "test-session-secret",
             "external_broker": {
                 "service_id": "bloom",
-                "login_url": "https://dev.login.lsmc.com/auth/login",
-                "handoff_exchange_url": "https://dev.login.lsmc.com/auth/handoff/consume",
+                "login_url": "https://dev.login.lsmc.com:8916/auth/login",
+                "handoff_exchange_url": "https://dev.login.lsmc.com:8916/auth/handoff/consume",
                 "callback_url": "https://localhost:8912/auth/lsmc/callback",
-                "logout_url": "https://dev.login.lsmc.com/auth/logout",
+                "logout_url": "https://dev.login.lsmc.com:8916/auth/logout",
             },
         }
     )
@@ -212,7 +212,7 @@ def test_external_broker_login_and_callback_create_session(
     location = login.headers["location"]
     parsed = urlparse(location)
     assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == (
-        "https://dev.login.lsmc.com/auth/login"
+        "https://dev.login.lsmc.com:8916/auth/login"
     )
     params = parse_qs(parsed.query)
     assert params["service"] == ["bloom"]


### PR DESCRIPTION
Fixes external broker browser sessions when the broker URL includes a port by passing only the parsed hostname to the Cognito web-session domain field.\n\nTests:\n- pytest tests/test_gui_auth_callback.py -q --no-cov\n- ruff check bloom_lims/gui/web_session.py tests/test_gui_auth_callback.py