### PR TITLE
[codex] Use canonical Bloom local user imports and roles

### DIFF
--- a/scripts/find_action.py
+++ b/scripts/find_action.py
@@ -1,41 +1,46 @@
 #!/usr/bin/env python3
 """Find action by name pattern in workflow hierarchy."""
-import sys
+
 import json
-sys.path.insert(0, '.')
+import sys
 
-from bloom_lims.db import BLOOMdb3
-from bloom_lims.bobjs import BloomObj
+sys.path.insert(0, ".")
 
-bobdb = BloomObj(BLOOMdb3(app_username='test@test.com'))
-obj = bobdb.get_by_euid('AY1')
+from bloom_lims.domain import BloomObj
+from bloom_lims.tapdb_adapter import BLOOMdb3
+
+bobdb = BloomObj(BLOOMdb3(app_username="test@test.com"))
+obj = bobdb.get_by_euid("AY1")
 
 found_actions = []
 
-def find_action(obj, action_name_pattern, depth=0):
-    if obj.json_addl and 'action_groups' in obj.json_addl:
-        for gk, gv in obj.json_addl['action_groups'].items():
-            for ak, av in gv.get('actions', {}).items():
-                if action_name_pattern.lower() in av.get('action_name', '').lower():
-                    found_actions.append({
-                        'euid': obj.euid,
-                        'action_key': ak,
-                        'action_name': av.get('action_name'),
-                        'captured_data': av.get('captured_data', {})
-                    })
 
-    if depth < 4 and hasattr(obj, 'parent_of_lineages'):
+def find_action(obj, action_name_pattern, depth=0):
+    if obj.json_addl and "action_groups" in obj.json_addl:
+        for gk, gv in obj.json_addl["action_groups"].items():
+            for ak, av in gv.get("actions", {}).items():
+                if action_name_pattern.lower() in av.get("action_name", "").lower():
+                    found_actions.append(
+                        {
+                            "euid": obj.euid,
+                            "action_key": ak,
+                            "action_name": av.get("action_name"),
+                            "captured_data": av.get("captured_data", {}),
+                        }
+                    )
+
+    if depth < 4 and hasattr(obj, "parent_of_lineages"):
         for lin in obj.parent_of_lineages[:30]:
             child = lin.child_instance
             if child and not child.is_deleted:
-                find_action(child, action_name_pattern, depth+1)
+                find_action(child, action_name_pattern, depth + 1)
+
 
 # Search for Register Specimen action
-find_action(obj, 'Register')
+find_action(obj, "Register")
 for a in found_actions:
     print(f"EUID: {a['euid']}")
     print(f"Action: {a['action_name']}")
     print(f"Key: {a['action_key']}")
     print(f"captured_data: {json.dumps(a['captured_data'], indent=2)}")
     print("---")
-

--- a/scripts/migrate_bloom_user_roles.py
+++ b/scripts/migrate_bloom_user_roles.py
@@ -18,7 +18,7 @@ from bloom_lims.auth.repositories.tapdb.users import (
     set_user_role,
 )
 from bloom_lims.auth.services.groups import GroupService
-from bloom_lims.db import BLOOMdb3
+from bloom_lims.tapdb_adapter import BLOOMdb3
 
 LEGACY_ROLE_GROUP_PRIORITY = (
     (BLOOM_ADMIN_GROUP.upper(), Role.ADMIN.value),

--- a/scripts/provision_local_user.py
+++ b/scripts/provision_local_user.py
@@ -13,7 +13,7 @@ from bloom_lims.auth.repositories.tapdb.users import (
     set_user_role,
 )
 from bloom_lims.auth.services.groups import GroupService
-from bloom_lims.db import BLOOMdb3
+from bloom_lims.tapdb_adapter import BLOOMdb3
 
 
 def main() -> int:
@@ -21,14 +21,20 @@ def main() -> int:
     parser.add_argument("--username", required=True)
     parser.add_argument("--email", default="")
     parser.add_argument("--name", required=True)
-    parser.add_argument("--role", default="admin")
+    parser.add_argument(
+        "--role",
+        required=True,
+        choices=["READ_ONLY", "READ_WRITE", "ADMIN"],
+    )
     parser.add_argument("--group", action="append", default=[])
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
 
     username = str(args.username).strip().lower()
     email = str(args.email or args.username).strip().lower()
-    role = normalize_persisted_role(args.role, default="ADMIN") or "ADMIN"
+    role = normalize_persisted_role(args.role, default=None)
+    if role is None:
+        raise RuntimeError("--role must be READ_ONLY, READ_WRITE, or ADMIN")
     groups = [str(group).strip().upper() for group in args.group if str(group).strip()]
 
     bdb = BLOOMdb3(app_username="local-provision")

--- a/tests/test_bloom_user_role_migration.py
+++ b/tests/test_bloom_user_role_migration.py
@@ -32,7 +32,7 @@ def test_infer_role_from_groups_prefers_admin_over_other_groups():
     assert MIGRATION._infer_role_from_groups(["bloom-readonly"]) == "READ_ONLY"
 
 
-def test_migrate_roles_uppercases_and_infers_missing_roles(monkeypatch):
+def test_migrate_roles_accepts_canonical_roles_and_infers_missing_roles(monkeypatch):
     calls: list[tuple[str, str]] = []
 
     class FakeSession:
@@ -51,7 +51,7 @@ def test_migrate_roles_uppercases_and_infers_missing_roles(monkeypatch):
 
     users = [
         SimpleNamespace(
-            uid=1, username="one@example.com", email="one@example.com", role="admin"
+            uid=1, username="one@example.com", email="one@example.com", role="ADMIN"
         ),
         SimpleNamespace(
             uid=2, username="two@example.com", email="two@example.com", role=""
@@ -96,9 +96,8 @@ def test_migrate_roles_uppercases_and_infers_missing_roles(monkeypatch):
 
     result = MIGRATION.migrate_roles(dry_run=False)
 
-    assert result["count"] == 3
+    assert result["count"] == 2
     assert result["removed_count"] == 2
-    assert ("one@example.com", "ADMIN") in calls
     assert ("two@example.com", "READ_WRITE") in calls
     assert ("three@example.com", "ADMIN") in calls
     assert ("remove:2", "bloom-readwrite") in calls

--- a/tests/test_provision_local_user_script.py
+++ b/tests/test_provision_local_user_script.py
@@ -87,7 +87,7 @@ def test_main_persists_canonical_role_with_uid(monkeypatch, capsys):
             "--name",
             "dayhoff@lsmc.bio",
             "--role",
-            "admin",
+            "ADMIN",
             "--group",
             "ENABLE_ATLAS_API",
             "--json",


### PR DESCRIPTION
## Summary
- update local Bloom provisioning scripts to use canonical modules instead of removed compatibility imports
- require canonical Bloom role values for local user provisioning
- update role migration/provision tests for the greenfield role contract

## Validation
- `source ./activate unidbtst >/tmp/bloom_activate.log && python -m py_compile scripts/provision_local_user.py scripts/migrate_bloom_user_roles.py scripts/find_action.py && pytest --no-cov tests/test_provision_local_user_script.py tests/test_bloom_user_role_migration.py -q && ruff check scripts/provision_local_user.py scripts/migrate_bloom_user_roles.py scripts/find_action.py tests/test_provision_local_user_script.py tests/test_bloom_user_role_migration.py && rg -n "from bloom_lims\\.(db|bobjs)" scripts bloom_lims tests --glob '!tests/#*' || true`
