### PR TITLE
Fix broker logout session origin

### DIFF
--- a/bloom_lims/gui/web_session.py
+++ b/bloom_lims/gui/web_session.py
@@ -47,7 +47,7 @@ def build_bloom_web_session_config(
             ),
             client_id=broker.service_id,
             redirect_uri=broker.callback_url,
-            logout_uri=broker.logout_url,
+            logout_uri=f"{public_base_url}/auth/logout",
             public_base_url=public_base_url,
             session_secret_key=_session_secret(auth_settings),
             session_cookie_name="bloom_session",

--- a/tests/test_gui_auth_callback.py
+++ b/tests/test_gui_auth_callback.py
@@ -33,7 +33,10 @@ import main  # noqa: E402
 from auth.cognito.client import CognitoConfigurationError  # noqa: E402
 from bloom_lims.config import BloomSettings  # noqa: E402
 from bloom_lims.gui.routes.auth import SessionBootstrapError  # noqa: E402
-from bloom_lims.gui.web_session import _normalize_user_data  # noqa: E402
+from bloom_lims.gui.web_session import (  # noqa: E402
+    _normalize_user_data,
+    build_bloom_web_session_config,
+)
 
 
 def _fake_cognito_config() -> SimpleNamespace:
@@ -165,6 +168,18 @@ def _external_broker_settings() -> BloomSettings:
             },
         }
     )
+
+
+def test_external_broker_session_config_uses_service_local_logout_uri(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _external_broker_settings()
+    monkeypatch.setattr("bloom_lims.gui.web_session.get_settings", lambda: settings)
+
+    session_config = build_bloom_web_session_config()
+
+    assert session_config.public_base_url == "https://localhost:8912"
+    assert session_config.logout_uri == "https://localhost:8912/auth/logout"
 
 
 def test_external_broker_login_and_callback_create_session(


### PR DESCRIPTION
## Summary
- keep external-broker session middleware on the Bloom service origin for logout URI validation
- preserve broker logout redirection in the route handler
- add focused regression coverage

## Tests
- source ./activate unidbtst >/tmp/bloom_activate.log && python -m py_compile bloom_lims/gui/web_session.py tests/test_gui_auth_callback.py && pytest --no-cov tests/test_gui_auth_callback.py::test_external_broker_session_config_uses_service_local_logout_uri tests/test_gui_auth_callback.py::test_external_broker_login_and_callback_create_session -q && ruff check bloom_lims/gui/web_session.py tests/test_gui_auth_callback.py && ruff format --check bloom_lims/gui/web_session.py tests/test_gui_auth_callback.py