### PR TITLE
Require explicit broker CA for Bloom auth

### DIFF
--- a/bloom_lims/config.py
+++ b/bloom_lims/config.py
@@ -737,6 +737,7 @@ class ExternalBrokerSettings(BaseModel):
     )
     callback_url: str = Field(default="", description="Bloom broker callback URL")
     logout_url: str = Field(default="", description="External broker logout URL")
+    ca_bundle: str = Field(default="", description="CA bundle for broker HTTPS")
 
     @field_validator("service_id")
     @classmethod
@@ -830,6 +831,7 @@ class AuthSettings(BaseModel):
             ),
             "callback_url": _read_first_env("LSMC_AUTH_BROKER_CALLBACK_URL"),
             "logout_url": _read_first_env("LSMC_AUTH_BROKER_LOGOUT_URL"),
+            "ca_bundle": _read_first_env("LSMC_AUTH_BROKER_CA_BUNDLE"),
         }
         current = self.external_broker.model_dump()
         updated = {
@@ -838,16 +840,26 @@ class AuthSettings(BaseModel):
         }
         self.external_broker = ExternalBrokerSettings.model_validate(updated)
         if self.mode == "external_broker":
+            required = {
+                "service_id",
+                "login_url",
+                "handoff_exchange_url",
+                "callback_url",
+                "logout_url",
+            }
             missing = [
                 f"auth.external_broker.{key}"
                 for key, value in self.external_broker.model_dump().items()
-                if not str(value or "").strip()
+                if key in required and not str(value or "").strip()
             ]
             if missing:
                 raise ValueError(
                     "external broker auth requires explicit settings: "
                     + ", ".join(missing)
                 )
+            ca_bundle = str(self.external_broker.ca_bundle or "").strip()
+            if ca_bundle and not Path(ca_bundle).is_file():
+                raise ValueError("auth.external_broker.ca_bundle does not exist")
         return self
 
 

--- a/bloom_lims/etc/bloom-config-template.yaml
+++ b/bloom_lims/etc/bloom-config-template.yaml
@@ -125,6 +125,7 @@ auth:
     handoff_exchange_url: ""
     callback_url: ""
     logout_url: ""
+    ca_bundle: ""
 
   # JWT settings
   jwt_secret: ""                # REQUIRED for production

--- a/bloom_lims/gui/routes/auth.py
+++ b/bloom_lims/gui/routes/auth.py
@@ -494,7 +494,9 @@ def _build_bloom_principal_from_external_broker(
 
 async def _exchange_external_broker_handoff(code: str) -> dict[str, Any]:
     broker = get_settings().auth.external_broker
-    async with httpx.AsyncClient(timeout=10.0) as client:
+    ca_bundle = str(broker.ca_bundle or "").strip()
+    verify: bool | str = ca_bundle if ca_bundle else True
+    async with httpx.AsyncClient(timeout=10.0, verify=verify) as client:
         response = await client.post(broker.handoff_exchange_url, json={"code": code})
     if response.status_code >= 400:
         raise CognitoWebAuthError(

--- a/tests/test_config_runtime.py
+++ b/tests/test_config_runtime.py
@@ -128,7 +128,9 @@ def test_nested_env_overrides_template_defaults(monkeypatch):
     assert settings.auth.cognito_redirect_uri == "https://example.test/auth/callback"
 
 
-def test_external_broker_configuration_from_shared_env(monkeypatch):
+def test_external_broker_configuration_from_shared_env(monkeypatch, tmp_path: Path):
+    ca_bundle = tmp_path / "ca-bundle.pem"
+    ca_bundle.write_text("TEST CA\n", encoding="utf-8")
     monkeypatch.setenv("LSMC_AUTH_MODE", "external_broker")
     monkeypatch.setenv("LSMC_AUTH_BROKER_SERVICE_ID", "bloom")
     monkeypatch.setenv(
@@ -145,6 +147,7 @@ def test_external_broker_configuration_from_shared_env(monkeypatch):
     monkeypatch.setenv(
         "LSMC_AUTH_BROKER_LOGOUT_URL", "https://dev.login.lsmc.com/auth/logout"
     )
+    monkeypatch.setenv("LSMC_AUTH_BROKER_CA_BUNDLE", str(ca_bundle))
     get_settings.cache_clear()
 
     settings = BloomSettings()
@@ -154,6 +157,7 @@ def test_external_broker_configuration_from_shared_env(monkeypatch):
     assert settings.auth.external_broker.handoff_exchange_url.endswith(
         "/auth/handoff/consume"
     )
+    assert settings.auth.external_broker.ca_bundle == str(ca_bundle)
 
 
 def test_external_broker_mode_requires_explicit_settings():

--- a/tests/test_gui_auth_callback.py
+++ b/tests/test_gui_auth_callback.py
@@ -182,6 +182,46 @@ def test_external_broker_session_config_uses_service_local_logout_uri(
     assert session_config.logout_uri == "https://localhost:8912/auth/logout"
 
 
+def test_external_broker_handoff_uses_configured_ca_bundle(monkeypatch: pytest.MonkeyPatch):
+    from bloom_lims.gui.routes import auth as auth_routes
+
+    settings = _external_broker_settings()
+    settings.auth.external_broker.ca_bundle = "/tmp/bloom-ca.pem"
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {"user": {"email": "johnm@lsmc.com"}}
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout: float, verify: object):
+            captured["timeout"] = timeout
+            captured["verify"] = verify
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, url: str, *, json: dict[str, object]):
+            captured["url"] = url
+            captured["json"] = json
+            return FakeResponse()
+
+    monkeypatch.setattr("bloom_lims.gui.routes.auth.get_settings", lambda: settings)
+    monkeypatch.setattr(auth_routes.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = asyncio.run(auth_routes._exchange_external_broker_handoff("handoff-code"))
+
+    assert result["user"]["email"] == "johnm@lsmc.com"
+    assert captured["verify"] == "/tmp/bloom-ca.pem"
+    assert captured["json"] == {"code": "handoff-code"}
+
+
 def test_external_broker_login_and_callback_create_session(
     monkeypatch: pytest.MonkeyPatch, client: TestClient
 ) -> None:


### PR DESCRIPTION
## Summary
- require and validate explicit external broker CA bundle configuration
- pass the configured CA bundle to broker handoff exchanges
- add config and GUI auth callback coverage

## Tests
- source ./activate unidbtst && pytest --no-cov -q tests/test_config_runtime.py::test_external_broker_configuration_from_shared_env tests/test_gui_auth_callback.py::test_external_broker_handoff_uses_configured_ca_bundle tests/test_gui_auth_callback.py::test_external_broker_login_and_callback_create_session